### PR TITLE
add printing query params in curl documentation

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/core/RestDocumentationResultHandlers.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/core/RestDocumentationResultHandlers.java
@@ -25,12 +25,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.StringWriter;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -81,7 +77,10 @@ public abstract class RestDocumentationResultHandlers {
 		};
 	}
 
-	private static final class CurlRequestDocumentationAction implements
+	/**
+	 * package visibility for tests
+	 */
+	static final class CurlRequestDocumentationAction implements
 			DocumentationAction {
 
 		private final DocumentationWriter writer;
@@ -100,9 +99,9 @@ public abstract class RestDocumentationResultHandlers {
 		@Override
 		public void perform() throws Exception {
 			MockHttpServletRequest request = this.result.getRequest();
-			this.writer.print(String.format("curl %s://%s:%d%s", request.getScheme(),
+			this.writer.print(String.format("curl %s://%s:%d%s%s", request.getScheme(),
 					request.getRemoteHost(), request.getRemotePort(),
-					request.getRequestURI()));
+					request.getRequestURI(), queryParamsToString(request)));
 
 			if (this.curlConfiguration.includeResponseHeaders) {
 				this.writer.print(" -i");
@@ -125,6 +124,44 @@ public abstract class RestDocumentationResultHandlers {
 			}
 
 			this.writer.println();
+		}
+
+		/**
+		 * returns query parameter representation in request e.g<br>
+		 * <code>?firstParam=firstValue&secondParam&thirdParam=thirdValue</code>
+		 * <br><br>
+		 * package visibility for tests
+		 */
+		String queryParamsToString(MockHttpServletRequest request) {
+
+			Enumeration<String> parameterNames = request.getParameterNames();
+
+			if(!parameterNames.hasMoreElements()){
+				return "";
+			}
+
+			StringBuilder sb = new StringBuilder("?");
+
+			while (parameterNames.hasMoreElements()){
+
+				String name = parameterNames.nextElement();
+
+				sb.append(name);
+
+				Object value = request.getParameter(name);
+				if(value != null){
+					sb.append("=");
+					sb.append(value);
+				}
+
+				if(parameterNames.hasMoreElements()){
+					sb.append("&");
+				}
+
+			}
+
+			return sb.toString();
+
 		}
 
 		private String getContent(MockHttpServletRequest request) throws IOException {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/core/CurlRequestDocumentationActionTest.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/core/CurlRequestDocumentationActionTest.java
@@ -1,0 +1,71 @@
+package org.springframework.restdocs.core;
+
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class CurlRequestDocumentationActionTest {
+
+    @Test
+    public void testQueryParamsToStringReturnsEmptyStringIfThereIsNoParams(){
+
+        RestDocumentationResultHandlers.CurlRequestDocumentationAction curlRequestDocumentationAction =
+                new RestDocumentationResultHandlers.CurlRequestDocumentationAction(null, null, null);
+
+        String queryParamsToString = curlRequestDocumentationAction.queryParamsToString(new MockHttpServletRequest());
+        assertTrue(queryParamsToString.isEmpty());
+
+    }
+
+    @Test
+    public void testQueryParamsToStringSingleParameter(){
+
+        RestDocumentationResultHandlers.CurlRequestDocumentationAction curlRequestDocumentationAction =
+                new RestDocumentationResultHandlers.CurlRequestDocumentationAction(null, null, null);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        request.addParameter("someParam", "someValue");
+
+        String queryParamsToString = curlRequestDocumentationAction.queryParamsToString(request);
+        assertEquals("?someParam=someValue", queryParamsToString);
+
+    }
+
+    @Test
+    public void testQueryParamsToStringMultipleParameters(){
+
+        RestDocumentationResultHandlers.CurlRequestDocumentationAction curlRequestDocumentationAction =
+                new RestDocumentationResultHandlers.CurlRequestDocumentationAction(null, null, null);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        request.addParameter("firstParam", "firstValue");
+        request.addParameter("secondParam", "secondValue");
+        request.addParameter("thirdParam", "thirdValue");
+
+        String queryParamsToString = curlRequestDocumentationAction.queryParamsToString(request);
+        assertEquals("?firstParam=firstValue&secondParam=secondValue&thirdParam=thirdValue", queryParamsToString);
+
+    }
+
+    @Test
+    public void testQueryParamsToStringParameterWithoutValue(){
+
+        RestDocumentationResultHandlers.CurlRequestDocumentationAction curlRequestDocumentationAction =
+                new RestDocumentationResultHandlers.CurlRequestDocumentationAction(null, null, null);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        request.addParameter("firstParam", "firstValue");
+        request.addParameter("secondParam", new String[0]);
+        request.addParameter("thirdParam", "thirdValue");
+
+        String queryParamsToString = curlRequestDocumentationAction.queryParamsToString(request);
+        assertEquals("?firstParam=firstValue&secondParam&thirdParam=thirdValue", queryParamsToString);
+
+    }
+
+}


### PR DESCRIPTION
Commit adds printing of request parameters in request documentation.
for example 
$ curl http://localhost:8080/settlement?id=123 -i -H "Accept: application/json"