### PR TITLE
Removed references to the spring-restdocs-core dependency and changed them into spring-restdocs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,11 @@ plugins {
 }
 ```
 
-Add a dependency on `spring-restdocs-core` in the `testCompile` configuration:
+Add a dependency on `spring-restdocs` in the `testCompile` configuration:
 
 ```groovy
 dependencies {
-	testCompile 'org.springframework.restdocs:spring-restdocs-core:0.1.0.BUILD-SNAPSHOT'
+	testCompile 'org.springframework.restdocs:spring-restdocs:0.1.0.BUILD-SNAPSHOT'
 }
 ```
 
@@ -138,12 +138,12 @@ jar {
 You can look at either samples' `pom.xml` file to see the required configuration. The key
 parts are described below:
 
-Add a dependency on `spring-restdocs-core` in the `test` scope:
+Add a dependency on `spring-restdocs` in the `test` scope:
 
 ```xml
 <dependency>
 	<groupId>org.springframework.restdocs</groupId>
-	<artifactId>spring-restdocs-core</artifactId>
+	<artifactId>spring-restdocs</artifactId>
 	<version>0.1.0.BUILD-SNAPSHOT</version>
 	<scope>test</scope>
 </dependency>


### PR DESCRIPTION
The spring-restdocs-core dependency is not used anymore but can still be retrieved from https://repo.spring.io/snapshot.
To avoid confusion it's important the readme file is up-to-date with the right dependency.