### PR TITLE
Fix "line.separator" (windows platform) issue on AsciidoctorWriterTests

### DIFF
--- a/spring-restdocs/src/test/java/org/springframework/restdocs/snippet/AsciidoctorWriterTests.java
+++ b/spring-restdocs/src/test/java/org/springframework/restdocs/snippet/AsciidoctorWriterTests.java
@@ -46,7 +46,7 @@ public class AsciidoctorWriterTests {
 			}
 		});
 
-		String expectedOutput = String.format("\n[source,java]\n----\nfoo\n----\n\n");
+		String expectedOutput = String.format("%n[source,java]%n----%nfoo%n----%n%n");
 		assertEquals(expectedOutput, this.output.toString());
 	}
 
@@ -60,7 +60,7 @@ public class AsciidoctorWriterTests {
 			}
 		});
 
-		String expectedOutput = String.format("\n[source,bash]\n----\n$ foo\n----\n\n");
+		String expectedOutput = String.format("%n[source,bash]%n----%n$ foo%n----%n%n");
 		assertEquals(expectedOutput, this.output.toString());
 	}
 }


### PR DESCRIPTION
The 2 tests of `AsciidoctorWriterTests` do not pass because of the `line.separator` which is `'\r\n'` on windows and not `'\n'` (expected by the test result).

This can be easily fixed by remplacing the `'\n'` occurences by `'%s'` in the expected String passed to the `String.format()' method :
```java
String expectedOutput = String.format("%n[source,bash]%n----%n$ foo%n----%n%n");
```