### PR TITLE
Improve quoting for cURL

### DIFF
--- a/spring-restdocs/src/main/java/org/springframework/restdocs/curl/CurlDocumentation.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/curl/CurlDocumentation.java
@@ -81,16 +81,16 @@ public abstract class CurlDocumentation {
 		public void perform() throws IOException {
 			DocumentableHttpServletRequest request = new DocumentableHttpServletRequest(
 					this.result.getRequest());
-			this.writer.print(String.format("curl %s://%s", request.getScheme(),
+			this.writer.print(String.format("curl '%s://%s", request.getScheme(),
 					request.getHost()));
 
 			if (isNonStandardPort(request)) {
 				this.writer.print(String.format(":%d", request.getPort()));
 			}
 
-			this.writer.print(request.getRequestUriWithQueryString().replace("&", "\\&"));
+			this.writer.print(request.getRequestUriWithQueryString());
 
-			this.writer.print(" -i");
+			this.writer.print("' -i");
 
 			if (!request.isGetRequest()) {
 				this.writer.print(String.format(" -X %s", request.getMethod()));
@@ -98,7 +98,7 @@ public abstract class CurlDocumentation {
 
 			for (Entry<String, List<String>> entry : request.getHeaders().entrySet()) {
 				for (String header : entry.getValue()) {
-					this.writer.print(String.format(" -H \"%s: %s\"", entry.getKey(),
+					this.writer.print(String.format(" -H '%s: %s'", entry.getKey(),
 							header));
 				}
 			}
@@ -110,8 +110,7 @@ public abstract class CurlDocumentation {
 			else if (request.isPostRequest()) {
 				String queryString = request.getParameterMapAsQueryString();
 				if (StringUtils.hasText(queryString)) {
-					this.writer.print(String.format(" -d '%s'",
-							queryString.replace("&", "\\&")));
+					this.writer.print(String.format(" -d '%s'", queryString));
 				}
 			}
 

--- a/spring-restdocs/src/test/java/org/springframework/restdocs/curl/CurlDocumentationTests.java
+++ b/spring-restdocs/src/test/java/org/springframework/restdocs/curl/CurlDocumentationTests.java
@@ -60,7 +60,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("get-request").handle(
 				new StubMvcResult(new MockHttpServletRequest("GET", "/foo"), null));
 		assertThat(requestSnippetLines("get-request"),
-				hasItem("$ curl http://localhost/foo -i"));
+				hasItem("$ curl 'http://localhost/foo' -i"));
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("non-get-request").handle(
 				new StubMvcResult(new MockHttpServletRequest("POST", "/foo"), null));
 		assertThat(requestSnippetLines("non-get-request"),
-				hasItem("$ curl http://localhost/foo -i -X POST"));
+				hasItem("$ curl 'http://localhost/foo' -i -X POST"));
 	}
 
 	@Test
@@ -78,7 +78,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("request-with-content").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("request-with-content"),
-				hasItem("$ curl http://localhost/foo -i -d 'content'"));
+				hasItem("$ curl 'http://localhost/foo' -i -d 'content'"));
 	}
 
 	@Test
@@ -87,7 +87,7 @@ public class CurlDocumentationTests {
 				new StubMvcResult(new MockHttpServletRequest("GET", "/foo?param=value"),
 						null));
 		assertThat(requestSnippetLines("request-with-uri-query-string"),
-				hasItem("$ curl http://localhost/foo?param=value -i"));
+				hasItem("$ curl 'http://localhost/foo?param=value' -i"));
 	}
 
 	@Test
@@ -97,7 +97,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("request-with-query-string").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("request-with-query-string"),
-				hasItem("$ curl http://localhost/foo?param=value -i"));
+				hasItem("$ curl 'http://localhost/foo?param=value' -i"));
 	}
 
 	@Test
@@ -107,7 +107,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("request-with-one-parameter").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("request-with-one-parameter"),
-				hasItem("$ curl http://localhost/foo?k1=v1 -i"));
+				hasItem("$ curl 'http://localhost/foo?k1=v1' -i"));
 	}
 
 	@Test
@@ -119,7 +119,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("request-with-multiple-parameters").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("request-with-multiple-parameters"),
-				hasItem("$ curl http://localhost/foo?k1=v1\\&k1=v1-bis\\&k2=v2 -i"));
+				hasItem("$ curl 'http://localhost/foo?k1=v1&k1=v1-bis&k2=v2' -i"));
 	}
 
 	@Test
@@ -129,7 +129,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("request-with-url-encoded-parameter").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("request-with-url-encoded-parameter"),
-				hasItem("$ curl http://localhost/foo?k1=foo+bar%26 -i"));
+				hasItem("$ curl 'http://localhost/foo?k1=foo+bar%26' -i"));
 	}
 
 	@Test
@@ -139,7 +139,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("post-request-with-one-parameter").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("post-request-with-one-parameter"),
-				hasItem("$ curl http://localhost/foo -i -X POST -d 'k1=v1'"));
+				hasItem("$ curl 'http://localhost/foo' -i -X POST -d 'k1=v1'"));
 	}
 
 	@Test
@@ -152,7 +152,7 @@ public class CurlDocumentationTests {
 				new StubMvcResult(request, null));
 		assertThat(
 				requestSnippetLines("post-request-with-multiple-parameters"),
-				hasItem("$ curl http://localhost/foo -i -X POST -d 'k1=v1\\&k1=v1-bis\\&k2=v2'"));
+				hasItem("$ curl 'http://localhost/foo' -i -X POST -d 'k1=v1&k1=v1-bis&k2=v2'"));
 	}
 
 	@Test
@@ -162,7 +162,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("post-request-with-url-encoded-parameter").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("post-request-with-url-encoded-parameter"),
-				hasItem("$ curl http://localhost/foo -i -X POST -d 'k1=a%26b'"));
+				hasItem("$ curl 'http://localhost/foo' -i -X POST -d 'k1=a%26b'"));
 	}
 
 	@Test
@@ -174,7 +174,7 @@ public class CurlDocumentationTests {
 				new StubMvcResult(request, null));
 		assertThat(
 				requestSnippetLines("request-with-headers"),
-				hasItem("$ curl http://localhost/foo -i -H \"Content-Type: application/json\" -H \"a: alpha\""));
+				hasItem("$ curl 'http://localhost/foo' -i -H 'Content-Type: application/json' -H 'a: alpha'"));
 	}
 
 	@Test
@@ -184,7 +184,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("http-with-non-standard-port").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("http-with-non-standard-port"),
-				hasItem("$ curl http://localhost:8080/foo -i"));
+				hasItem("$ curl 'http://localhost:8080/foo' -i"));
 	}
 
 	@Test
@@ -195,7 +195,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("https-with-standard-port").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("https-with-standard-port"),
-				hasItem("$ curl https://localhost/foo -i"));
+				hasItem("$ curl 'https://localhost/foo' -i"));
 	}
 
 	@Test
@@ -206,7 +206,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("https-with-non-standard-port").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("https-with-non-standard-port"),
-				hasItem("$ curl https://localhost:8443/foo -i"));
+				hasItem("$ curl 'https://localhost:8443/foo' -i"));
 	}
 
 	@Test
@@ -216,7 +216,7 @@ public class CurlDocumentationTests {
 		documentCurlRequest("request-with-custom-host").handle(
 				new StubMvcResult(request, null));
 		assertThat(requestSnippetLines("request-with-custom-host"),
-				hasItem("$ curl http://api.example.com/foo -i"));
+				hasItem("$ curl 'http://api.example.com/foo' -i"));
 	}
 
 	private List<String> requestSnippetLines(String snippetName) throws IOException {


### PR DESCRIPTION
Single quotes are generally safer to use since shells won't try to interpolate
any strings or do variable substitution inside it. This could be refined to do
a check for [&%$] inside the URI/query string before just blindly surrounding
with quotes, but this is safe as it is. I'd also argue it improve readability to not
have to deal with mentally unescaping the command-line.

Also, don't escape POST payloads since they are quoted already -- this doesn't
work correctly right now.