### PR TITLE
Whenever the first part of the Content-Type header field matches, a Link...

### DIFF
--- a/spring-restdocs/src/main/java/org/springframework/restdocs/hypermedia/LinkExtractors.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/hypermedia/LinkExtractors.java
@@ -17,17 +17,12 @@
 package org.springframework.restdocs.hypermedia;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletResponse;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Static factory methods providing a selection of {@link LinkExtractor link extractors}
@@ -70,10 +65,13 @@ public abstract class LinkExtractors {
 	 * @return The extractor for the content type, or {@code null}
 	 */
 	public static LinkExtractor extractorForContentType(String contentType) {
-		if (MediaType.APPLICATION_JSON_VALUE.equals(contentType)) {
+		if (null == contentType) {
+			return null;
+		}
+		if (contentType.startsWith(MediaType.APPLICATION_JSON_VALUE)) {
 			return atomLinks();
 		}
-		else if ("application/hal+json".equals(contentType)) {
+		else if (contentType.startsWith("application/hal+json")) {
 			return halLinks();
 		}
 		return null;

--- a/spring-restdocs/src/main/java/org/springframework/restdocs/hypermedia/LinkExtractors.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/hypermedia/LinkExtractors.java
@@ -17,7 +17,11 @@
 package org.springframework.restdocs.hypermedia;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,18 +64,15 @@ public abstract class LinkExtractors {
 	/**
 	 * Returns the {@code LinkExtractor} for the given {@code contentType} or {@code null}
 	 * if there is no extractor for the content type.
-	 * 
-	 * @param contentType The content type
+	 *
+	 * @param contentType The content type, may include parameters
 	 * @return The extractor for the content type, or {@code null}
 	 */
 	public static LinkExtractor extractorForContentType(String contentType) {
-		if (null == contentType) {
-			return null;
-		}
-		if (contentType.startsWith(MediaType.APPLICATION_JSON_VALUE)) {
+		if (MediaType.parseMediaType(contentType).isCompatibleWith(MediaType.APPLICATION_JSON)) {
 			return atomLinks();
 		}
-		else if (contentType.startsWith("application/hal+json")) {
+		else if (MediaType.parseMediaType(contentType).isCompatibleWith(new MediaType("application","hal+json"))) {
 			return halLinks();
 		}
 		return null;

--- a/spring-restdocs/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsTests.java
+++ b/spring-restdocs/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsTests.java
@@ -16,27 +16,19 @@
 
 package org.springframework.restdocs.hypermedia;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.core.IsNull.*;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.restdocs.hypermedia.Link;
-import org.springframework.restdocs.hypermedia.LinkExtractor;
-import org.springframework.restdocs.hypermedia.LinkExtractors;
 import org.springframework.util.FileCopyUtils;
 
 /**
@@ -61,6 +53,13 @@ public class LinkExtractorsTests {
 		this.linkExtractor = linkExtractor;
 		this.linkType = linkType;
 	}
+
+	@Test
+	public void combinedContentTypeMatches() {
+		LinkExtractor linkExtractor = LinkExtractors.extractorForContentType("application/json;charset=UTF-8");
+		assertThat(linkExtractor, notNullValue());
+	}
+
 
 	@Test
 	public void singleLink() throws IOException {

--- a/spring-restdocs/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsTests.java
+++ b/spring-restdocs/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsTests.java
@@ -16,18 +16,26 @@
 
 package org.springframework.restdocs.hypermedia;
 
-import static org.hamcrest.core.IsNull.*;
-import static org.junit.Assert.*;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.util.FileCopyUtils;
 
@@ -54,12 +62,22 @@ public class LinkExtractorsTests {
 		this.linkType = linkType;
 	}
 
+	@Test(expected = InvalidMediaTypeException.class)
+	public void emptyContentType() {
+		LinkExtractors.extractorForContentType(null);
+	}
+
 	@Test
 	public void combinedContentTypeMatches() {
 		LinkExtractor linkExtractor = LinkExtractors.extractorForContentType("application/json;charset=UTF-8");
 		assertThat(linkExtractor, notNullValue());
 	}
 
+	@Test
+	public void notDefinedMediaTypesMatches() {
+		LinkExtractor linkExtractor = LinkExtractors.extractorForContentType("application/hal+json;charset=UTF-8");
+		assertThat(linkExtractor, notNullValue());
+	}
 
 	@Test
 	public void singleLink() throws IOException {


### PR DESCRIPTION
...Extractor is returned. CharSet information at the end of the Content-Type has no affect. Fixes gh-56