### PR TITLE
Support PUT requests.

### DIFF
--- a/spring-restdocs/src/main/java/org/springframework/restdocs/curl/CurlDocumentation.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/curl/CurlDocumentation.java
@@ -114,7 +114,7 @@ public abstract class CurlDocumentation {
 				this.writer
 						.print(String.format(" -d '%s'", request.getContentAsString()));
 			}
-			else if (request.isPostRequest()) {
+			else if (request.isPostRequest() || request.isPutRequest()) {
 				String queryString = request.getParameterMapAsQueryString();
 				if (StringUtils.hasText(queryString)) {
 					this.writer.print(String.format(" -d '%s'", queryString));

--- a/spring-restdocs/src/main/java/org/springframework/restdocs/http/HttpDocumentation.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/http/HttpDocumentation.java
@@ -32,7 +32,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Static factory methods for documenting a RESTful API's HTTP requests.
- * 
+ *
  * @author Andy Wilkinson
  */
 public abstract class HttpDocumentation {
@@ -44,7 +44,7 @@ public abstract class HttpDocumentation {
 	/**
 	 * Produces a documentation snippet containing the request formatted as an HTTP
 	 * request
-	 * 
+	 *
 	 * @param outputDir The directory to which snippet should be written
 	 * @return the handler that will produce the snippet
 	 */
@@ -63,7 +63,7 @@ public abstract class HttpDocumentation {
 	/**
 	 * Produces a documentation snippet containing the response formatted as the HTTP
 	 * response sent by the server
-	 * 
+	 *
 	 * @param outputDir The directory to which snippet should be written
 	 * @return the handler that will produce the snippet
 	 */
@@ -109,7 +109,7 @@ public abstract class HttpDocumentation {
 			if (request.getContentLength() > 0) {
 				this.writer.println(request.getContentAsString());
 			}
-			else if (request.isPostRequest()) {
+			else if (request.isPostRequest() || request.isPutRequest()) {
 				String queryString = request.getParameterMapAsQueryString();
 				if (StringUtils.hasText(queryString)) {
 					this.writer.println(queryString);
@@ -120,7 +120,7 @@ public abstract class HttpDocumentation {
 		private boolean requiresFormEncodingContentType(
 				DocumentableHttpServletRequest request) {
 			return request.getHeaders().getContentType() == null
-					&& request.isPostRequest()
+					&& (request.isPostRequest() || request.isPutRequest())
 					&& StringUtils.hasText(request.getParameterMapAsQueryString());
 		}
 	}

--- a/spring-restdocs/src/main/java/org/springframework/restdocs/util/DocumentableHttpServletRequest.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/util/DocumentableHttpServletRequest.java
@@ -35,7 +35,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 /**
  * An {@link HttpServletRequest} wrapper that provides a limited set of methods intended
  * to help in the documentation of the request.
- * 
+ *
  * @author Andy Wilkinson
  *
  */
@@ -46,7 +46,7 @@ public class DocumentableHttpServletRequest {
 	/**
 	 * Creates a new {@link DocumentableHttpServletRequest} to document the given
 	 * {@code request}.
-	 * 
+	 *
 	 * @param request the request that is to be documented
 	 */
 	public DocumentableHttpServletRequest(MockHttpServletRequest request) {
@@ -55,7 +55,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Whether or not this request is a {@code GET} request.
-	 * 
+	 *
 	 * @return {@code true} if it is a {@code GET} request, otherwise {@code false}
 	 * @see HttpServletRequest#getMethod()
 	 */
@@ -65,7 +65,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Whether or not this request is a {@code POST} request.
-	 * 
+	 *
 	 * @return {@code true} if it is a {@code POST} request, otherwise {@code false}
 	 * @see HttpServletRequest#getMethod()
 	 */
@@ -74,10 +74,20 @@ public class DocumentableHttpServletRequest {
 	}
 
 	/**
+	 * Whether or not this request is a {@code PUT} request.
+	 *
+	 * @return {@code true} if it is a {@code PUT} request, otherwise {@code false}
+	 * @see HttpServletRequest#getMethod()
+	 */
+	public boolean isPutRequest() {
+		return RequestMethod.PUT == RequestMethod.valueOf(this.delegate.getMethod());
+	}
+
+	/**
 	 * Returns the request's headers. The headers are ordered based on the ordering of
 	 * {@link HttpServletRequest#getHeaderNames()} and
 	 * {@link HttpServletRequest#getHeaders(String)}.
-	 * 
+	 *
 	 * @return the request's headers
 	 * @see HttpServletRequest#getHeaderNames()
 	 * @see HttpServletRequest#getHeaders(String)
@@ -94,7 +104,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Returns the request's scheme.
-	 * 
+	 *
 	 * @return the request's scheme
 	 * @see HttpServletRequest#getScheme()
 	 */
@@ -104,7 +114,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Returns the name of the host to which the request was sent.
-	 * 
+	 *
 	 * @return the host's name
 	 * @see HttpServletRequest#getServerName()
 	 */
@@ -114,7 +124,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Returns the port to which the request was sent.
-	 * 
+	 *
 	 * @return the port
 	 * @see HttpServletRequest#getServerPort()
 	 */
@@ -124,7 +134,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Returns the request's method.
-	 * 
+	 *
 	 * @return the request's method
 	 * @see HttpServletRequest#getMethod()
 	 */
@@ -134,7 +144,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Returns the length of the request's content
-	 * 
+	 *
 	 * @return the content length
 	 * @see HttpServletRequest#getContentLength()
 	 */
@@ -144,7 +154,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Returns a {@code String} of the request's content
-	 * 
+	 *
 	 * @return the request's content
 	 * @throws IOException if the content cannot be read
 	 */
@@ -159,7 +169,7 @@ public class DocumentableHttpServletRequest {
 	 * determined by calling {@link HttpServletRequest#getQueryString()}. If it's
 	 * {@code null} and it is a {@code GET} request, the query string is then constructed
 	 * from the request's {@link HttpServletRequest#getParameterMap()} parameter map.
-	 * 
+	 *
 	 * @return the URI of the request, including its query string
 	 */
 	public String getRequestUriWithQueryString() {
@@ -174,7 +184,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Returns the request's parameter map formatted as a query string
-	 * 
+	 *
 	 * @return The query string derived from the request's parameter map
 	 * @see HttpServletRequest#getParameterMap()
 	 */
@@ -184,7 +194,7 @@ public class DocumentableHttpServletRequest {
 
 	/**
 	 * Returns the request's context path
-	 * 
+	 *
 	 * @return The context path of the request
 	 * @see HttpServletRequest#getContextPath()
 	 */

--- a/spring-restdocs/src/test/java/org/springframework/restdocs/curl/CurlDocumentationTests.java
+++ b/spring-restdocs/src/test/java/org/springframework/restdocs/curl/CurlDocumentationTests.java
@@ -21,6 +21,7 @@ import static org.springframework.restdocs.test.SnippetMatchers.codeBlock;
 import static org.springframework.restdocs.test.StubMvcResult.result;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 import java.io.IOException;
 
@@ -32,7 +33,7 @@ import org.springframework.restdocs.test.ExpectedSnippet;
 
 /**
  * Tests for {@link CurlDocumentation}
- * 
+ *
  * @author Andy Wilkinson
  * @author Yann Le Guern
  * @author Dmitriy Mayboroda
@@ -132,6 +133,36 @@ public class CurlDocumentationTests {
 								"$ curl 'http://localhost/foo' -i -X POST -d 'k1=a%26b'"));
 		documentCurlRequest("post-request-with-url-encoded-parameter").handle(
 				result(post("/foo").param("k1", "a&b")));
+	}
+
+	@Test
+	public void putRequestWithOneParameter() throws IOException {
+		this.snippet.expectCurlRequest("put-request-with-one-parameter").withContents(
+				codeBlock("bash").content(
+						"$ curl 'http://localhost/foo' -i -X PUT -d 'k1=v1'"));
+		documentCurlRequest("put-request-with-one-parameter").handle(
+				result(put("/foo").param("k1", "v1")));
+	}
+
+	@Test
+	public void putRequestWithMultipleParameters() throws IOException {
+		this.snippet.expectCurlRequest("put-request-with-multiple-parameters")
+				.withContents(
+						codeBlock("bash").content(
+								"$ curl 'http://localhost/foo' -i -X PUT"
+										+ " -d 'k1=v1&k1=v1-bis&k2=v2'"));
+		documentCurlRequest("put-request-with-multiple-parameters").handle(
+				result(put("/foo").param("k1", "v1", "v1-bis").param("k2", "v2")));
+	}
+
+	@Test
+	public void putRequestWithUrlEncodedParameter() throws IOException {
+		this.snippet.expectCurlRequest("put-request-with-url-encoded-parameter")
+				.withContents(
+						codeBlock("bash").content(
+								"$ curl 'http://localhost/foo' -i -X PUT -d 'k1=a%26b'"));
+		documentCurlRequest("put-request-with-url-encoded-parameter").handle(
+				result(put("/foo").param("k1", "a&b")));
 	}
 
 	@Test

--- a/spring-restdocs/src/test/java/org/springframework/restdocs/http/HttpDocumentationTests.java
+++ b/spring-restdocs/src/test/java/org/springframework/restdocs/http/HttpDocumentationTests.java
@@ -25,8 +25,10 @@ import static org.springframework.restdocs.test.SnippetMatchers.httpResponse;
 import static org.springframework.restdocs.test.StubMvcResult.result;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
+import static org.springframework.web.bind.annotation.RequestMethod.PUT;
 
 import java.io.IOException;
 
@@ -38,7 +40,7 @@ import org.springframework.restdocs.test.ExpectedSnippet;
 
 /**
  * Tests for {@link HttpDocumentation}
- * 
+ *
  * @author Andy Wilkinson
  */
 public class HttpDocumentationTests {
@@ -92,6 +94,27 @@ public class HttpDocumentationTests {
 
 		documentHttpRequest("post-request-with-parameter").handle(
 				result(post("/foo").param("b&r", "baz").param("a", "alpha")));
+	}
+
+	@Test
+	public void putRequestWithContent() throws IOException {
+		this.snippet.expectHttpRequest("put-request-with-content").withContents(
+				httpRequest(PUT, "/foo") //
+						.content("Hello, world"));
+
+		documentHttpRequest("put-request-with-content").handle(
+				result(put("/foo").content("Hello, world")));
+	}
+
+	@Test
+	public void putRequestWithParameter() throws IOException {
+		this.snippet.expectHttpRequest("put-request-with-parameter").withContents(
+				httpRequest(PUT, "/foo") //
+						.header("Content-Type", "application/x-www-form-urlencoded") //
+						.content("b%26r=baz&a=alpha"));
+
+		documentHttpRequest("put-request-with-parameter").handle(
+				result(put("/foo").param("b&r", "baz").param("a", "alpha")));
 	}
 
 	@Test


### PR DESCRIPTION
@wilkinsona I am not sure why only `POST` requests are being handled by the documentation generator, but this PR adds support for `PUT` requests as well (treats them identically to `POST` requests).  I noticed when using the library that `PUT` parameters were not being generated as part of the documentation like for `POST`'s.