### PR TITLE
Create a more generic pattern-replacing post-processor

### DIFF
--- a/spring-restdocs/src/main/java/org/springframework/restdocs/response/LinkMaskingResponsePostProcessor.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/response/LinkMaskingResponsePostProcessor.java
@@ -16,40 +16,21 @@
 
 package org.springframework.restdocs.response;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-class LinkMaskingResponsePostProcessor extends ContentModifyingReponsePostProcessor {
+class LinkMaskingResponsePostProcessor extends PatternReplacingResponsePostProcessor {
 
 	private static final String DEFAULT_MASK = "...";
 
 	private static final Pattern LINK_HREF = Pattern.compile(
 			"\"href\"\\s*:\\s*\"(.*?)\"", Pattern.DOTALL);
 
-	private final String mask;
-
 	LinkMaskingResponsePostProcessor() {
-		this(DEFAULT_MASK);
+		super(LINK_HREF, DEFAULT_MASK);
 	}
 
 	LinkMaskingResponsePostProcessor(String mask) {
-		this.mask = mask;
-	}
-
-	@Override
-	protected String modifyContent(String originalContent) {
-		Matcher matcher = LINK_HREF.matcher(originalContent);
-		StringBuilder buffer = new StringBuilder();
-		int previous = 0;
-		while (matcher.find()) {
-			buffer.append(originalContent.substring(previous, matcher.start(1)));
-			buffer.append(this.mask);
-			previous = matcher.end(1);
-		}
-		if (previous < originalContent.length()) {
-			buffer.append(originalContent.substring(previous));
-		}
-		return buffer.toString();
+		super(LINK_HREF, mask);
 	}
 
 }

--- a/spring-restdocs/src/main/java/org/springframework/restdocs/response/PatternReplacingResponsePostProcessor.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/response/PatternReplacingResponsePostProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.response;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class PatternReplacingResponsePostProcessor extends ContentModifyingReponsePostProcessor {
+
+	private final Pattern pattern;
+
+	private final String replacement;
+
+	public PatternReplacingResponsePostProcessor(Pattern pattern, String replacement) {
+		this.pattern = pattern;
+		this.replacement = replacement;
+	}
+
+	@Override
+	protected String modifyContent(String originalContent) {
+		Matcher matcher = pattern.matcher(originalContent);
+		StringBuilder buffer = new StringBuilder();
+		int previous = 0;
+		while (matcher.find()) {
+			buffer.append(originalContent.substring(previous, matcher.start(1)));
+			buffer.append(this.replacement);
+			previous = matcher.end(1);
+		}
+		if (previous < originalContent.length()) {
+			buffer.append(originalContent.substring(previous));
+		}
+		return buffer.toString();
+	}
+
+}

--- a/spring-restdocs/src/main/java/org/springframework/restdocs/response/ResponsePostProcessors.java
+++ b/spring-restdocs/src/main/java/org/springframework/restdocs/response/ResponsePostProcessors.java
@@ -16,6 +16,8 @@
 
 package org.springframework.restdocs.response;
 
+import java.util.regex.Pattern;
+
 /**
  * Static factory methods for accessing various {@link ResponsePostProcessor
  * ResponsePostProcessors}.
@@ -71,4 +73,17 @@ public abstract class ResponsePostProcessors {
 	public static ResponsePostProcessor maskLinksWith(String mask) {
 		return new LinkMaskingResponsePostProcessor(mask);
 	}
+
+	/**
+	 * Returns a {@link ResponsePostProcessor} that will replace any occurrences of
+	 * the given pattern with a replacement string in the response.
+	 *
+	 * @param pattern the pattern to match
+	 * @param replacement the string to replace it with
+	 * @return the response post-processor
+	 */
+	public static ResponsePostProcessor replacePattern(Pattern pattern, String replacement) {
+		return new PatternReplacingResponsePostProcessor(pattern, replacement);
+	}
+
 }

--- a/spring-restdocs/src/test/java/org/springframework/restdocs/RestDocumentationIntegrationTests.java
+++ b/spring-restdocs/src/test/java/org/springframework/restdocs/RestDocumentationIntegrationTests.java
@@ -24,6 +24,7 @@ import static org.springframework.restdocs.RestDocumentation.modifyResponseTo;
 import static org.springframework.restdocs.response.ResponsePostProcessors.maskLinks;
 import static org.springframework.restdocs.response.ResponsePostProcessors.prettyPrintContent;
 import static org.springframework.restdocs.response.ResponsePostProcessors.removeHeaders;
+import static org.springframework.restdocs.response.ResponsePostProcessors.replacePattern;
 import static org.springframework.restdocs.test.SnippetMatchers.httpResponse;
 import static org.springframework.restdocs.test.SnippetMatchers.snippet;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,6 +34,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.junit.After;
 import org.junit.Before;
@@ -154,6 +156,21 @@ public class RestDocumentationIntegrationTests {
 								.content(
 										"{\"a\":\"alpha\",\"links\":[{\"rel\":\"rel\","
 												+ "\"href\":\"href\"}]}"))));
+
+		Pattern pattern = Pattern.compile("(\"alpha\")");
+		mockMvc.perform(get("/").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andDo(modifyResponseTo(prettyPrintContent(), removeHeaders("a"),
+						replacePattern(pattern, "\"<<beta>>\"")).andDocument("post-processed"));
+
+		assertThat(
+				new File("build/generated-snippets/post-processed/http-response.adoc"),
+				is(snippet().withContents(
+						httpResponse(HttpStatus.OK).header("Content-Type",
+								"application/json").content(
+								String.format("{%n  \"a\" : \"<<beta>>\",%n  \"links\" :"
+										+ " [ {%n    \"rel\" : \"rel\",%n    \"href\" :"
+										+ " \"href\"%n  } ]%n}")))));
 
 		mockMvc.perform(get("/").accept(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())

--- a/spring-restdocs/src/test/java/org/springframework/restdocs/response/PatternReplacingResponsePostProcessorTests.java
+++ b/spring-restdocs/src/test/java/org/springframework/restdocs/response/PatternReplacingResponsePostProcessorTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.response;
+
+import org.junit.Test;
+
+import java.util.regex.Pattern;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PatternReplacingResponsePostProcessorTests {
+
+	@Test
+	public void patternsAreReplaced() throws Exception {
+		Pattern pattern = Pattern.compile("([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})",
+				Pattern.CASE_INSENSITIVE);
+		PatternReplacingResponsePostProcessor postProcessor = new PatternReplacingResponsePostProcessor(
+				pattern, "<<uuid>>");
+		assertThat(postProcessor.modifyContent("{\"id\" : \"CA761232-ED42-11CE-BACD-00AA0057B223\"}"),
+				is(equalTo("{\"id\" : \"<<uuid>>\"}")));
+	}
+
+}


### PR DESCRIPTION
...and make the link masker extend it. Like I showed in the unit test, our use-case is actually to do some anonymising of data along the way.