### PR TITLE
Configure Gradle to add generated documentation to resources not the jar directly

### DIFF
--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -81,13 +81,13 @@ then use this attribute when including the generated snippets in your documentat
 
 You may want to package the generated documentation in your project's jar file, for
 example to have it {spring-boot-docs}/#boot-features-spring-mvc-static-content[served as
-static content] by Spring Boot. You can do so by configuring the `jar` task to depend on
-the `asciidoctor` task and to copy the generated documentation into the jar's static
-directory:
+static content] by Spring Boot. You can do so by configuring the `processResources` task to depend on
+the `asciidoctor` task and add the generated documentation to the jar file as
+resources in `static/docs`.
 
 [source,groovy,indent=0]
 ----
-	jar {
+	processResources {
 		dependsOn asciidoctor
 		from ("${asciidoctor.outputDir}/html5") {
 			into 'static/docs'


### PR DESCRIPTION
While playing around with Spring Rest Docs and Spring Boot I run into a problem: When I run the application using

    ./gradlew bootRun

the generated documentation is not accessible on the embedded Tomcat server.
This is because the ``bootRun`` task from the Spring Boot Gradle Plugin does not depend on ``jar`` so copying the documentation using the jar task can not work.

This can be solved by copying the documentation earlier in the ``processResources`` task. 