### PR TITLE
Add -u 'username:password' in the curl snippet

### DIFF
--- a/spring-restdocs-core/build.gradle
+++ b/spring-restdocs-core/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	compile 'junit:junit'
 	compile 'org.springframework:spring-webmvc'
 	compile 'javax.servlet:javax.servlet-api'
+	compile 'commons-codec:commons-codec:1.10'
 	compile files(jmustacheRepackJar)
 	jarjar 'com.googlecode.jarjar:jarjar:1.3'
 	jmustache 'com.samskivert:jmustache@jar'

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/curl/CurlRequestSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/curl/CurlRequestSnippetTests.java
@@ -36,6 +36,7 @@ import org.springframework.restdocs.templates.TemplateResourceResolver;
 import org.springframework.restdocs.templates.mustache.MustacheTemplateEngine;
 import org.springframework.restdocs.test.ExpectedSnippet;
 import org.springframework.restdocs.test.OperationBuilder;
+import org.springframework.util.Base64Utils;
 
 /**
  * Tests for {@link CurlRequestSnippet}
@@ -44,6 +45,7 @@ import org.springframework.restdocs.test.OperationBuilder;
  * @author Yann Le Guern
  * @author Dmitriy Mayboroda
  * @author Jonathan Pearlin
+ * @author Paul-Christian Volkmer
  */
 public class CurlRequestSnippetTests {
 
@@ -255,6 +257,16 @@ public class CurlRequestSnippetTests {
 						.attribute(TemplateEngine.class.getName(),
 								new MustacheTemplateEngine(resolver))
 						.request("http://localhost/foo").build());
+	}
+
+	@Test
+	public void httpBasicAuthorizationHeader() throws IOException {
+		this.snippet.expectCurlRequest("get-request")
+				.withContents(codeBlock("bash").content("$ curl 'http://localhost/foo' -i -u 'user:secret'"));
+		new CurlRequestSnippet().document(new OperationBuilder("get-request", this.snippet.getOutputDirectory())
+				.request("http://localhost/foo")
+				.header(HttpHeaders.AUTHORIZATION, "Basic " + Base64Utils.encodeToString("user:secret".getBytes()))
+				.build());
 	}
 
 }


### PR DESCRIPTION
Add -u 'username:password' in the curl snippet when request has
a basic auth header and ignore this header in writeHeaders().

Fixes gh-120