### PR TITLE
Configure the build to use Checkstyle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ subprojects {
 	apply plugin: 'propdeps-eclipse'
 	apply plugin: 'propdeps-maven'
 	apply plugin: 'maven'
+	apply plugin: 'checkstyle'
 	apply from: "${rootProject.projectDir}/gradle/publish-maven.gradle"
 
 	sourceCompatibility = 1.7
@@ -69,6 +70,10 @@ subprojects {
 			dependency 'org.springframework.hateoas:spring-hateoas:0.17.0.RELEASE'
 			dependency 'org.jacoco:org.jacoco.agent:0.7.2.201409121644'
 		}
+	}
+
+	checkstyle {
+		configFile = rootProject.file('checkstyle.xml')
 	}
 
 	configurations {

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -7,7 +7,7 @@
 
 	<!-- Checks whether files end with a new line. -->
 	<!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
-	<module name="NewlineAtEndOfFile"/>
+<!-- 	<module name="NewlineAtEndOfFile"/> -->
 
 	<module name="FileLength" />
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.2//EN" "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+
+<!-- A simple set of Checkstyle rules -->
+<module name="Checker">
+
+	<!-- Checks whether files end with a new line. -->
+	<!-- See http://checkstyle.sf.net/config_misc.html#NewlineAtEndOfFile -->
+	<module name="NewlineAtEndOfFile"/>
+
+	<module name="FileLength" />
+
+	<module name="RegexpSingleline">
+		<property name="format" value="System\.(out|err)\.print" />
+		<property name="message"
+			value="System.out.println and System.err.println are not allowed. Using logging instead." />
+	</module>
+	<module name="RegexpSingleline">
+		<property name="format" value="\.printStackTrace\(\)" />
+		<property name="message"
+			value="Calls to Throwable.printStackTrace() are not allowed. Log the exception instead." />
+	</module>
+
+	<module name="TreeWalker">
+
+		<!-- Checks for Naming Conventions. -->
+		<!-- See http://checkstyle.sf.net/config_naming.html -->
+		<module name="ConstantName" />
+		<module name="LocalFinalVariableName" />
+		<module name="LocalVariableName" />
+		<module name="MemberName" />
+		<module name="MethodName" />
+		<module name="PackageName" />
+		<module name="ParameterName" />
+		<module name="StaticVariableName" />
+		<module name="TypeName" />
+
+		<!-- Checks for imports -->
+		<!-- See http://checkstyle.sf.net/config_import.html -->
+		<module name="AvoidStarImport" />
+		<module name="IllegalImport" /> <!-- defaults to sun.* packages -->
+<!-- 		<module name="RedundantImport" /> -->
+<!-- 		<module name="UnusedImports" /> -->
+
+		<!-- Checks for Size Violations. -->
+		<!-- Size checks - http://checkstyle.sourceforge.net/config_sizes.html -->
+		<module name="MethodLength" />
+		<module name="ParameterNumber" />
+<!-- 		<module name="LineLengthCheck"> -->
+<!-- 			<property name="max" value="120" /> -->
+<!-- 			<property name="tabWidth" value="4" /> -->
+<!-- 			<property name="ignorePattern" value="^import" /> -->
+<!-- 		</module> -->
+
+		<!-- Block checks - http://checkstyle.sourceforge.net/config_blocks.html -->
+		<module name="LeftCurly" />
+<!-- 		<module name="RightCurly"/> -->
+		<module name="NeedBraces" />
+
+		<!-- Metrics checks - http://checkstyle.sourceforge.net/config_metrics.html -->
+		<module name="JavaNCSS">
+			<property name="methodMaximum" value="32" />
+			<property name="classMaximum" value="500" />
+		</module>
+		<module name="CyclomaticComplexity">
+			<property name="max" value="10" />
+		</module>
+		<module name="NPathComplexity">
+			<property name="max" value="32" />
+		</module>
+
+		<!-- Coding checks http://checkstyle.sourceforge.net/config_coding.html -->
+		<module name="EmptyStatement" />
+		<module name="EqualsHashCode" />
+		<module name="IllegalInstantiation" />
+		<module name="InnerAssignment" />
+		<module name="MissingSwitchDefault" />
+		<module name="SimplifyBooleanExpression" />
+		<module name="SimplifyBooleanReturn" />
+		<module name="StringLiteralEquality" />
+		<module name="NestedIfDepth">
+			<property name="max" value="2" />
+		</module>
+		<module name="NestedTryDepth">
+			<property name="max" value="2" />
+		</module>
+		<module name="NoFinalizer" />
+
+	</module>
+
+</module>

--- a/docs/src/test/java/com/example/ExampleApplicationTests.java
+++ b/docs/src/test/java/com/example/ExampleApplicationTests.java
@@ -27,7 +27,7 @@ import org.springframework.web.context.WebApplicationContext;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 
 public class ExampleApplicationTests {
-	
+
 	// tag::mock-mvc-setup[]
 	@Rule
 	public final RestDocumentation restDocumentation = new RestDocumentation("build/generated-snippets");


### PR DESCRIPTION
This commit adds checkstyle plugin and provides a simple config file.

The configuration file is placed in projects root folder and should be
enhanced to contain all needed checks.
Some failing checks are disabled within this config file.

Fixes gh-119