### PR TITLE
add sourceDir to asciidoc task inputs

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -16,4 +16,5 @@ asciidoctor {
 	attributes	'revnumber': project.version,
 				'branch-or-tag': project.version.endsWith('SNAPSHOT') ? 'master': "v${project.version}"
 	inputs.files(sourceSets.test.java)
+	inputs.dir sourceDir
 }

--- a/samples/rest-notes-spring-hateoas/build.gradle
+++ b/samples/rest-notes-spring-hateoas/build.gradle
@@ -51,6 +51,7 @@ asciidoctor {
 	sourceDir 'src/main/asciidoc' // Align with Maven's default location
 	attributes 'snippets': snippetsDir
 	inputs.dir snippetsDir
+	inputs.dir sourceDir
 	dependsOn test
 }
 


### PR DESCRIPTION
I haven't signed the spring CLA yet, but I expect this to be just a "trivial patch".
asciidoctor does not register the sourceDir as task input, so the up-to-date check, or gradle continuous mode (-t) does not pick up changes in this directory.

