### PR TITLE
This commit adds basic bracket notation support

### DIFF
--- a/docs/src/docs/asciidoc/documenting-your-api.adoc
+++ b/docs/src/docs/asciidoc/documenting-your-api.adoc
@@ -92,8 +92,10 @@ must be compatible with `application/xml`.
 [[documenting-your-api-request-response-payloads-json-field-paths]]
 ===== JSON field paths
 
-JSON field paths use `.` to descend into a child object and `[]` to identify an array. For
-example, with this JSON payload:
+JSON field paths use `.` or bracket notation to descend into a child object and `[]` to
+identify an array. Using bracket notation enables the use of `.` within a key name.
+
+For example, with this JSON payload:
 
 [source,json,indent=0]
 ----
@@ -109,7 +111,8 @@ example, with this JSON payload:
 				{
 					"d":"three"
 				}
-			]
+			],
+			"e.dot" : "four"
 		}
 	}
 ----
@@ -126,6 +129,15 @@ The following paths are all present:
 |`a.b`
 |An array containing three objects
 
+|`['a']['b']`
+|An array containing three objects
+
+|`a['b']`
+|An array containing three objects
+
+|`['a'].b`
+|An array containing three objects
+
 |`a.b[]`
 |An array containing three objects
 
@@ -134,6 +146,14 @@ The following paths are all present:
 
 |`a.b[].d`
 |The string `three`
+
+|`a['e.dot']`
+|The string `four`
+
+|`['a']['e.dot']`
+|The string `four`
+
+
 |===
 
 

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
@@ -27,6 +27,7 @@ import org.junit.Test;
  * Tests for {@link JsonFieldPath}
  * 
  * @author Andy Wilkinson
+ * @author Jeremy Rickard
  */
 public class JsonFieldPathTests {
 
@@ -108,6 +109,21 @@ public class JsonFieldPathTests {
 	public void compilationOfPathStartingWithAnArray() {
 		assertThat(JsonFieldPath.compile("[]a.b.c").getSegments(),
 				contains("[]", "a", "b", "c"));
+	}
+
+	@Test
+	public void compilationOfMultipleElementPathWithBrackets() {
+		assertThat(JsonFieldPath.compile("['a']['b']['c']").getSegments(), contains("a", "b", "c"));
+	}
+
+	@Test
+	public void compilationOfMultipleElementPathWithAndWithoutBrackets() {
+		assertThat(JsonFieldPath.compile("['a'][].b['c']").getSegments(), contains("a", "[]", "b", "c"));
+	}
+
+	@Test
+	public void compilationOfMultipleElementPathWithAndWithoutBracketsAndEmbeddedDots() {
+		assertThat(JsonFieldPath.compile("['a.key'][].b['c']").getSegments(), contains("a.key", "[]", "b", "c"));
 	}
 
 }


### PR DESCRIPTION
This commit adds basic bracket notation support to JsonFieldPath.
With this commit, existing functionality remains as is, but users can
now use a basic form of JsonPath bracket notation. This enables the use
of Json keys with embedded dots. i.e. something like :

{
	"a.b" : "one"
}

  .andDo(document("licensedetails",responseFields(
                        fieldWithPath("['license.mode']")......

Fixes gh-131