### PR TITLE
NPE when documenting xml attribute of xml payload

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/XmlContentHandler.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/XmlContentHandler.java
@@ -34,6 +34,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -115,7 +116,15 @@ class XmlContentHandler implements ContentHandler {
 			}
 			for (int i = 0; i < matchingNodes.getLength(); i++) {
 				Node node = matchingNodes.item(i);
-				node.getParentNode().removeChild(node);
+
+				if (node.getNodeType() == Node.ATTRIBUTE_NODE) {
+					Attr attr = (Attr) node;
+					attr.getOwnerElement().removeAttributeNode(attr);
+				}
+				else {
+					node.getParentNode().removeChild(node);
+				}
+
 			}
 		}
 		if (payload.getChildNodes().getLength() > 0) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
@@ -192,6 +192,21 @@ public class ResponseFieldsSnippetTests {
 						.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML_VALUE)
 						.build());
 	}
+	
+	@Test
+	public void undocumentedXmlWithAttributeResponseField() throws IOException {
+		this.thrown.expect(SnippetException.class);
+		this.thrown
+				.expectMessage(equalTo("The following parts of the payload were not"
+						+ " documented:\r\n<a>\r\n    <b>5</b>\r\n</a>\r\n"));
+		new ResponseFieldsSnippet(Arrays.asList(new FieldDescriptor("/a/b/@id").type("").description("")))
+				.document(new OperationBuilder("undocumented-xml-response-field",
+						this.snippet.getOutputDirectory())
+						.response()
+						.content("<a><b id=\"1\">5</b></a>")
+						.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML_VALUE)
+						.build());
+	}
 
 	@Test
 	public void xmlResponseFieldWithNoType() throws IOException {


### PR DESCRIPTION
Documenting a xml attribute in the xml payload leads to a
NullPointerException since no parent nodes exists for a xml attribute.
So check if node is an attribute and remove the attribute if so.

Fixes [gh-166](https://github.com/spring-projects/spring-restdocs/issues/166)