### PR TITLE
Add support for pattern when removing headers

### DIFF
--- a/docs/src/docs/asciidoc/customizing-requests-and-responses.adoc
+++ b/docs/src/docs/asciidoc/customizing-requests-and-responses.adoc
@@ -105,6 +105,8 @@ different replacement can also be specified if you wish.
 `removeHeaders` on `Preprocessors` removes any occurrences of the named headers
 from the request or response.
 
+`removeMatchingHeaders` on `Preprocessors` applies the given patterns on every header and
+removes them when matching.
 
 
 [[customizing-requests-and-responses-preprocessors-replace-patterns]]

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/Preprocessors.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/Preprocessors.java
@@ -76,11 +76,26 @@ public final class Preprocessors {
 	 * Returns an {@code OperationPreprocessor} that will remove headers from the request
 	 * or response.
 	 *
-	 * @param headersToRemove the names of the headers to remove
+	 * @param headersToRemove the names of the headers to remove.
 	 * @return the preprocessor
 	 */
 	public static OperationPreprocessor removeHeaders(String... headersToRemove) {
 		return new HeaderRemovingOperationPreprocessor(headersToRemove);
+	}
+
+	/**
+	 * Returns an {@code OperationPreprocessor} that will remove headers from the request
+	 * or response based on a pattern match.
+	 *
+	 * @param headerPatternsToRemove pattern for the header names to remove. Every matchig header will be removed.
+	 * @return the preprocessor
+	 */
+	public static OperationPreprocessor removeMatchingHeaders(String... headerPatternsToRemove) {
+		Pattern[] patterns = new Pattern[headerPatternsToRemove.length];
+		for (int i = 0; i < headerPatternsToRemove.length; i++) {
+			patterns[i] = Pattern.compile(headerPatternsToRemove[i]);
+		}
+		return new HeaderRemovingOperationPreprocessor(patterns);
 	}
 
 	/**


### PR DESCRIPTION
`String` and `java.util.regex.Pattern` can both now be used as arguments to `removeHeaders` preprocessor method. When a Pattern is used then all matching headers are removed.

Fix gh-191

The CLA has been submitted. 