### PR TITLE
Restored the mention of Spring Framework 4.1 as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ To learn more about Spring REST Docs, please consult the [reference documentatio
 
 ## Building from source
 
-Spring REST Docs requires Java 7 or later and is built using [Gradle][10]:
+Spring REST Docs requires Spring Framework 4.1 and Java 7 or later and is built 
+using [Gradle][10]:
 
 ```
 ./gradlew build


### PR DESCRIPTION
The mention of Spring Framework 4.1 as a requirement for Spring REST Docs was previously added in the readme (ea77bd5) has been removed when most of the content of the readme was moved to the documentation (8a0b075).

Most articles and documents about Spring REST Docs don't mention this, which means that people usually get stuck when tying to configure ```MockMvc```in their tests. Having this information in the readme is a nice time saver.