### PR TITLE
Moved applyPathPrefix to PayloadDocumentation

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/AbstractFieldsSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/AbstractFieldsSnippet.java
@@ -204,30 +204,4 @@ public abstract class AbstractFieldsSnippet extends TemplatedSnippet {
 		return model;
 	}
 
-	/**
-	 * Creates a copy of the given {@code descriptors} with the given {@code pathPrefix}
-	 * applied to their paths.
-	 *
-	 * @param pathPrefix the path prefix
-	 * @param descriptors the descriptors to copy
-	 * @return the copied descriptors with the prefix applied
-	 */
-	protected final List<FieldDescriptor> applyPathPrefix(String pathPrefix,
-			List<FieldDescriptor> descriptors) {
-		List<FieldDescriptor> prefixedDescriptors = new ArrayList<>();
-		for (FieldDescriptor descriptor : descriptors) {
-			FieldDescriptor prefixedDescriptor = new FieldDescriptor(
-					pathPrefix + descriptor.getPath())
-							.description(descriptor.getDescription())
-							.type(descriptor.getType());
-			if (descriptor.isIgnored()) {
-				prefixedDescriptor.ignored();
-			}
-			if (descriptor.isOptional()) {
-				prefixedDescriptor.optional();
-			}
-			prefixedDescriptors.add(prefixedDescriptor);
-		}
-		return prefixedDescriptors;
-	}
 }

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/PayloadDocumentation.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/PayloadDocumentation.java
@@ -16,7 +16,9 @@
 
 package org.springframework.restdocs.payload;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -262,6 +264,33 @@ public abstract class PayloadDocumentation {
 	public static ResponseFieldsSnippet relaxedResponseFields(
 			Map<String, Object> attributes, FieldDescriptor... descriptors) {
 		return new ResponseFieldsSnippet(Arrays.asList(descriptors), attributes, true);
+	}
+
+	/**
+	 * Creates a copy of the given {@code descriptors} with the given {@code pathPrefix}
+	 * applied to their paths.
+	 *
+	 * @param pathPrefix the path prefix
+	 * @param descriptors the descriptors to copy
+	 * @return the copied descriptors with the prefix applied
+	 */
+	public static List<FieldDescriptor> applyPathPrefix(String pathPrefix,
+			List<FieldDescriptor> descriptors) {
+		List<FieldDescriptor> prefixedDescriptors = new ArrayList<>();
+		for (FieldDescriptor descriptor : descriptors) {
+			FieldDescriptor prefixedDescriptor = new FieldDescriptor(
+					pathPrefix + descriptor.getPath())
+					.description(descriptor.getDescription())
+					.type(descriptor.getType());
+			if (descriptor.isIgnored()) {
+				prefixedDescriptor.ignored();
+			}
+			if (descriptor.isOptional()) {
+				prefixedDescriptor.optional();
+			}
+			prefixedDescriptors.add(prefixedDescriptor);
+		}
+		return prefixedDescriptors;
 	}
 
 }

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/RequestFieldsSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/RequestFieldsSnippet.java
@@ -138,7 +138,7 @@ public class RequestFieldsSnippet extends AbstractFieldsSnippet {
 		List<FieldDescriptor> combinedDescriptors = new ArrayList<>();
 		combinedDescriptors.addAll(getFieldDescriptors());
 		combinedDescriptors.addAll(
-				applyPathPrefix(pathPrefix, Arrays.asList(additionalDescriptors)));
+				PayloadDocumentation.applyPathPrefix(pathPrefix, Arrays.asList(additionalDescriptors)));
 		return new RequestFieldsSnippet(combinedDescriptors, this.getAttributes());
 	}
 
@@ -156,7 +156,8 @@ public class RequestFieldsSnippet extends AbstractFieldsSnippet {
 			List<FieldDescriptor> additionalDescriptors) {
 		List<FieldDescriptor> combinedDescriptors = new ArrayList<>(
 				getFieldDescriptors());
-		combinedDescriptors.addAll(applyPathPrefix(pathPrefix, additionalDescriptors));
+		combinedDescriptors.addAll(
+				PayloadDocumentation.applyPathPrefix(pathPrefix, additionalDescriptors));
 		return new RequestFieldsSnippet(combinedDescriptors, this.getAttributes());
 	}
 

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/ResponseFieldsSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/ResponseFieldsSnippet.java
@@ -139,7 +139,7 @@ public class ResponseFieldsSnippet extends AbstractFieldsSnippet {
 		List<FieldDescriptor> combinedDescriptors = new ArrayList<>();
 		combinedDescriptors.addAll(getFieldDescriptors());
 		combinedDescriptors.addAll(
-				applyPathPrefix(pathPrefix, Arrays.asList(additionalDescriptors)));
+				PayloadDocumentation.applyPathPrefix(pathPrefix, Arrays.asList(additionalDescriptors)));
 		return new ResponseFieldsSnippet(combinedDescriptors, this.getAttributes());
 	}
 
@@ -157,7 +157,8 @@ public class ResponseFieldsSnippet extends AbstractFieldsSnippet {
 			List<FieldDescriptor> additionalDescriptors) {
 		List<FieldDescriptor> combinedDescriptors = new ArrayList<>(
 				getFieldDescriptors());
-		combinedDescriptors.addAll(applyPathPrefix(pathPrefix, additionalDescriptors));
+		combinedDescriptors.addAll(
+				PayloadDocumentation.applyPathPrefix(pathPrefix, additionalDescriptors));
 		return new ResponseFieldsSnippet(combinedDescriptors, this.getAttributes());
 	}
 


### PR DESCRIPTION
Moved `applyPathPrefix` from `AbstractFieldsSnippet` to static method in `PayloadDocumentation`.