### PR TITLE
Add Support for cURL Snippets with Line Breaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 target
 .idea
 *.iml
+/.nb-gradle/

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineBreakStrategies.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineBreakStrategies.java
@@ -137,7 +137,7 @@ public final class CurlLineBreakStrategies {
 			implements CurlLineBreakStrategy {
 
 		@Override
-		public List<CurlLineGroup> getLinesGroups() {
+		public List<CurlLineGroup> getLineGroups() {
 			return Arrays.asList(new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
 					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
 					CurlPart.HEADERS, CurlPart.MULTIPARTS, CurlPart.CONTENT));
@@ -158,7 +158,7 @@ public final class CurlLineBreakStrategies {
 			implements CurlLineBreakStrategy {
 
 		@Override
-		public List<CurlLineGroup> getLinesGroups() {
+		public List<CurlLineGroup> getLineGroups() {
 			CurlLineGroup allButHeaders = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
 					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
 					CurlPart.MULTIPARTS, CurlPart.CONTENT);
@@ -181,7 +181,7 @@ public final class CurlLineBreakStrategies {
 			implements CurlLineBreakStrategy {
 
 		@Override
-		public List<CurlLineGroup> getLinesGroups() {
+		public List<CurlLineGroup> getLineGroups() {
 			CurlLineGroup allButParts = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
 					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
 					CurlPart.HEADERS, CurlPart.CONTENT);
@@ -204,7 +204,7 @@ public final class CurlLineBreakStrategies {
 			implements CurlLineBreakStrategy {
 
 		@Override
-		public List<CurlLineGroup> getLinesGroups() {
+		public List<CurlLineGroup> getLineGroups() {
 			CurlLineGroup optionsMethodContent = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
 					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
 					CurlPart.CONTENT);
@@ -228,7 +228,7 @@ public final class CurlLineBreakStrategies {
 			implements CurlLineBreakStrategy {
 
 		@Override
-		public List<CurlLineGroup> getLinesGroups() {
+		public List<CurlLineGroup> getLineGroups() {
 			CurlLineGroup optionsAndMethod = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
 					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
 					CurlPart.MULTIPARTS);
@@ -252,7 +252,7 @@ public final class CurlLineBreakStrategies {
 			implements CurlLineBreakStrategy {
 
 		@Override
-		public List<CurlLineGroup> getLinesGroups() {
+		public List<CurlLineGroup> getLineGroups() {
 			CurlLineGroup allButContent = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
 					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
 					CurlPart.HEADERS, CurlPart.MULTIPARTS);

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineBreakStrategies.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineBreakStrategies.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.cli;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Static factory methods to create {@link CurlLineBreakStrategy}s, which determine
+ * how line breaking should occur in the cURL snippet.
+ *
+ * @author Paul Samsotha
+ * @since 1.1.1
+ */
+public final class CurlLineBreakStrategies {
+
+	private CurlLineBreakStrategies() {
+
+	}
+
+	/**
+	 * A factory method that returns the default line-breaking strategy. No new lines
+	 * will be appended. Everything will be on one line. Using this strategy, you will
+	 * content like:
+	 *
+	 * <pre>
+	 * $ curl 'http://localhost/foo' -i -X POST -H 'X-Header-One: ONE' -d 'Some Content'
+	 * </pre>
+	 *
+	 * @return the default line break strategy.
+	 */
+	public static CurlLineBreakStrategy none() {
+		return new DefaultCurlLineBreakStrategy();
+	}
+
+	/**
+	 * A factory method that returns a line-breaking strategy that only adds line
+	 * breaks for headers. Using this strategy, you should see a snippet like:
+	 *
+	 * <pre>
+	 *  $ curl 'http://localhost/foo' -i -X POST  -d 'Some Content' \
+	 *  -H 'X-Header-One: ONE' \
+	 *  -H 'X-Header-Two: TWO' \
+	 *  -H 'X-Header-Three: THREE'
+	 * </pre>
+	 *
+	 * @return the line-break strategy that adds line breaks for each header.
+	 */
+	public static CurlLineBreakStrategy headersOnly() {
+		return new HeadersOnlyCurlLineBreakStrategy();
+	}
+
+	/**
+	 * A factory method that returns a line-breaking strategy that only adds line
+	 * breaks for multiparts. Using this strategy, you will see a snippet like:
+	 *
+	 * <pre>
+	 * $ curl 'http://localhost/foo' -i -X POST -H 'X-Header-One: ONE' \
+	 *  -F 'field1=Field1Data' \
+	 *  -F 'field2=Field2Data'
+	 * </pre>
+	 *
+	 * @return the line-break strategy that adds line breaks for each multipart.
+	 */
+	public static CurlLineBreakStrategy partsOnly() {
+		return new PartsOnlyCurlLineBreakStrategy();
+	}
+
+	/**
+	 * A factory method that returns a line-breaking strategy that adds line breaks
+	 * for both headers and multiparts. Using this strategy, you will see a snippet like:
+	 *
+	 * <pre>
+	 * $ curl 'http://localhost/foo' -i -X POST \
+	 *  -H 'X-Header-One: ONE' \
+	 *  -H 'X-Header-Two: TWO' \
+	 *  -H 'X-Header-Three: THREE' \
+	 *  -F 'field1=Field1Data' \
+	 *  -F 'field2=Field2Data'
+	 * </pre>
+	 *
+	 * @return the line-break strategy that breaks for headers and parts.
+	 */
+	public static CurlLineBreakStrategy headersAndParts() {
+		return new HeadersAndPartsCurlLineBreakStrategy();
+	}
+
+	/**
+	 * A factory method that returns a line-breaking strategy that puts only the
+	 * content on its own line. Using this strategy, you will see a snippet like:
+	 *
+	 * <pre>
+	 * $ curl 'http://localhost/foo' -i -X POST -H 'X-Header-One: ONE' \
+	 *  -d 'a=aplha&amp;b=bravo'
+	 * </pre>
+	 *
+	 * @return the line-break strategy that puts only the content on its own line.
+	 */
+	public static CurlLineBreakStrategy contentOnly() {
+		return new ContentOnlyPartsCurlLineBreakStrategy();
+	}
+
+	/**
+	 * A factory method that return a line-breaking strategy that adds line breaks
+	 * for headers and content. The content will come after the headers. Using this
+	 * strategy, you will see a snippet like
+	 *
+	 * <pre>
+	 * $ curl 'http://localhost/foo' -i -X POST \
+	 *  -H 'X-Header-One: ONE' \
+	 *  -H 'X-Header-Two: TWO' \
+	 *  -H 'X-Header-Three: THREE' \
+	 *  -d 'Some Content'
+	 * </pre>
+	 *
+	 * @return the line-break strategy that puts headers and content on their own line.
+	 */
+	public static CurlLineBreakStrategy headersAndContent() {
+		return new HeadersAndContentCurlLineBreakStrategy();
+	}
+
+	private static final class DefaultCurlLineBreakStrategy
+			implements CurlLineBreakStrategy {
+
+		@Override
+		public List<CurlLineGroup> getLinesGroups() {
+			return Arrays.asList(new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
+					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
+					CurlPart.HEADERS, CurlPart.MULTIPARTS, CurlPart.CONTENT));
+		}
+
+		@Override
+		public boolean splitHeaders() {
+			return false;
+		}
+
+		@Override
+		public boolean splitMultiParts() {
+			return false;
+		}
+	}
+
+	private static final class HeadersOnlyCurlLineBreakStrategy
+			implements CurlLineBreakStrategy {
+
+		@Override
+		public List<CurlLineGroup> getLinesGroups() {
+			CurlLineGroup allButHeaders = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
+					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
+					CurlPart.MULTIPARTS, CurlPart.CONTENT);
+			CurlLineGroup headers = new CurlLineGroup(CurlPart.HEADERS);
+			return Arrays.asList(allButHeaders, headers);
+		}
+
+		@Override
+		public boolean splitHeaders() {
+			return true;
+		}
+
+		@Override
+		public boolean splitMultiParts() {
+			return false;
+		}
+	}
+
+	private static final class PartsOnlyCurlLineBreakStrategy
+			implements CurlLineBreakStrategy {
+
+		@Override
+		public List<CurlLineGroup> getLinesGroups() {
+			CurlLineGroup allButParts = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
+					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
+					CurlPart.HEADERS, CurlPart.CONTENT);
+			CurlLineGroup multiparts = new CurlLineGroup(CurlPart.MULTIPARTS);
+			return Arrays.asList(allButParts, multiparts);
+		}
+
+		@Override
+		public boolean splitHeaders() {
+			return false;
+		}
+
+		@Override
+		public boolean splitMultiParts() {
+			return true;
+		}
+	}
+
+	private static final class HeadersAndPartsCurlLineBreakStrategy
+			implements CurlLineBreakStrategy {
+
+		@Override
+		public List<CurlLineGroup> getLinesGroups() {
+			CurlLineGroup optionsMethodContent = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
+					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
+					CurlPart.CONTENT);
+			CurlLineGroup headers = new CurlLineGroup(CurlPart.HEADERS);
+			CurlLineGroup multiparts = new CurlLineGroup(CurlPart.MULTIPARTS);
+			return Arrays.asList(optionsMethodContent, headers, multiparts);
+		}
+
+		@Override
+		public boolean splitHeaders() {
+			return true;
+		}
+
+		@Override
+		public boolean splitMultiParts() {
+			return true;
+		}
+	}
+
+	private static final class HeadersAndContentCurlLineBreakStrategy
+			implements CurlLineBreakStrategy {
+
+		@Override
+		public List<CurlLineGroup> getLinesGroups() {
+			CurlLineGroup optionsAndMethod = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
+					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
+					CurlPart.MULTIPARTS);
+			CurlLineGroup headers = new CurlLineGroup(CurlPart.HEADERS);
+			CurlLineGroup content = new CurlLineGroup(CurlPart.CONTENT);
+			return Arrays.asList(optionsAndMethod, headers, content);
+		}
+
+		@Override
+		public boolean splitHeaders() {
+			return true;
+		}
+
+		@Override
+		public boolean splitMultiParts() {
+			return false;
+		}
+	}
+
+	private static final class ContentOnlyPartsCurlLineBreakStrategy
+			implements CurlLineBreakStrategy {
+
+		@Override
+		public List<CurlLineGroup> getLinesGroups() {
+			CurlLineGroup allButContent = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
+					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
+					CurlPart.HEADERS, CurlPart.MULTIPARTS);
+			CurlLineGroup content = new CurlLineGroup(CurlPart.CONTENT);
+			return Arrays.asList(allButContent, content);
+		}
+
+		@Override
+		public boolean splitHeaders() {
+			return false;
+		}
+
+		@Override
+		public boolean splitMultiParts() {
+			return false;
+		}
+	}
+}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineBreakStrategy.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineBreakStrategy.java
@@ -33,7 +33,7 @@ public interface CurlLineBreakStrategy {
 	 *
 	 * @return return the list of line groups.
 	 */
-	List<CurlLineGroup> getLinesGroups();
+	List<CurlLineGroup> getLineGroups();
 
 	/**
 	 * Returns whether or not individual headers should be separately split in their

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineBreakStrategy.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineBreakStrategy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.cli;
+
+import java.util.List;
+
+/**
+ * A strategy used to determine the ordering of cURL parts, and how lines should
+ * be broken between those parts.
+ *
+ * @author Paul Samsotha
+ * @since 1.1.1
+ * @see CurlLineBreakStrategies
+ */
+public interface CurlLineBreakStrategy {
+
+	/**
+	 * A list of {@link CurlLineGroup}s that will determine the ordering of each group.
+	 *
+	 * @return return the list of line groups.
+	 */
+	List<CurlLineGroup> getLinesGroups();
+
+	/**
+	 * Returns whether or not individual headers should be separately split in their
+	 * own line.
+	 *
+	 * @return true if the individual headers should have their own line, false if not.
+	 */
+	boolean splitHeaders();
+
+	/**
+	 * Returns whether or not individual multiparts should be separately split in
+	 * their own line.
+	 *
+	 * @return true if the individual parts should have their own line, false if not.
+	 */
+	boolean splitMultiParts();
+}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineGroup.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlLineGroup.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.cli;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A group of cURL parts that should be included in one line.
+ *
+ * @author Paul Samsotha
+ * @since 1.1.1
+ */
+public class CurlLineGroup {
+
+	private final List<CurlPart> parts;
+
+	/**
+	 * Construct a line group with a variable number of cURL parts.
+	 *
+	 * @param parts the cURL parts.
+	 */
+	public CurlLineGroup(CurlPart... parts) {
+		this.parts = Arrays.asList(parts);
+	}
+
+	/**
+	 * Returns the list of cURL parts in this line group.
+	 *
+	 * @return the list of cURL parts.
+	 */
+	public List<CurlPart> getParts() {
+		return this.parts;
+	}
+}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlPart.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlPart.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.cli;
+
+/**
+ * An enum representing the different type of cURL command line parts.
+ *
+ * @author Paul Samsotha
+ * @since 1.1.1
+ */
+public enum CurlPart {
+
+	/**
+	 * {@code -u} in cURL (for authentication).
+	 */
+	USER_OPTION,
+
+	/**
+	 * {@code -i} in cURL (to show headers).
+	 */
+	SHOW_HEADER_OPTION,
+
+	/**
+	 * The HTTP Method.
+	 */
+	HTTP_METHOD,
+
+	/**
+	 * The headers.
+	 */
+	HEADERS, MULTIPARTS,
+
+	/**
+	 * The request content.
+	 */
+	CONTENT;
+}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlRequestSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlRequestSnippet.java
@@ -109,7 +109,7 @@ public class CurlRequestSnippet extends TemplatedSnippet {
 		List<WriteAction> writeActions = new ArrayList<>();
 		Map<CurlPart, WriteAction> map = getWriteActionMap();
 
-		Iterator<CurlLineGroup> it = lineBreaks.getLinesGroups().iterator();
+		Iterator<CurlLineGroup> it = lineBreaks.getLineGroups().iterator();
 		while (it.hasNext()) {
 			CurlLineGroup lineGroup = it.next();
 			boolean groupHasContent = false;

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlRequestSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlRequestSnippet.java
@@ -18,14 +18,15 @@ package org.springframework.restdocs.cli;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import org.springframework.http.HttpMethod;
 import org.springframework.restdocs.operation.Operation;
-import org.springframework.restdocs.operation.OperationRequest;
 import org.springframework.restdocs.operation.OperationRequestPart;
 import org.springframework.restdocs.operation.Parameters;
 import org.springframework.restdocs.snippet.Snippet;
@@ -37,9 +38,11 @@ import org.springframework.util.StringUtils;
  *
  * @author Andy Wilkinson
  * @author Paul-Christian Volkmer
+ * @author Paul Samsotha
  * @since 1.1.0
  * @see CliDocumentation#curlRequest()
  * @see CliDocumentation#curlRequest(Map)
+ * @see CurlLineBreakStrategy
  */
 public class CurlRequestSnippet extends TemplatedSnippet {
 
@@ -75,86 +78,284 @@ public class CurlRequestSnippet extends TemplatedSnippet {
 	private String getOptions(Operation operation) {
 		StringWriter command = new StringWriter();
 		PrintWriter printer = new PrintWriter(command);
-		writeIncludeHeadersInOutputOption(printer);
+
+		CurlLineBreakStrategy lineBreak;
+		Object attribute = operation.getAttributes().get(CurlLineBreakStrategy.class.getName());
+		if (attribute == null || !(attribute instanceof CurlLineBreakStrategy)) {
+			lineBreak = CurlLineBreakStrategies.none();
+		}
+		else {
+			lineBreak = (CurlLineBreakStrategy) operation.getAttributes()
+					.get(CurlLineBreakStrategy.class.getName());
+		}
 		CliOperationRequest request = new CliOperationRequest(operation.getRequest());
-		writeUserOptionIfNecessary(request, printer);
-		writeHttpMethodIfNecessary(request, printer);
-		writeHeaders(request, printer);
-		writePartsIfNecessary(request, printer);
-		writeContent(request, printer);
+
+		List<WriteAction> actions = resolveWriteActions(lineBreak, request);
+		for (WriteAction action : actions) {
+			action.write(request, printer);
+		}
 
 		return command.toString();
 	}
 
-	private void writeIncludeHeadersInOutputOption(PrintWriter writer) {
-		writer.print("-i");
-	}
+	/**
+	 * Resolves a list of write actions, based on the line break strategy.
+	 *
+	 * @param lineBreaks the line break strategy.
+	 * @return the list of write actions.
+	 */
+	private List<WriteAction> resolveWriteActions(CurlLineBreakStrategy lineBreaks,
+			CliOperationRequest request) {
+		List<WriteAction> writeActions = new ArrayList<>();
+		Map<CurlPart, WriteAction> map = getWriteActionMap();
 
-	private void writeUserOptionIfNecessary(CliOperationRequest request,
-			PrintWriter writer) {
-		String credentials = request.getBasicAuthCredentials();
-		if (credentials != null) {
-			writer.print(String.format(" -u '%s'", credentials));
-		}
-	}
-
-	private void writeHttpMethodIfNecessary(OperationRequest request,
-			PrintWriter writer) {
-		if (!HttpMethod.GET.equals(request.getMethod())) {
-			writer.print(String.format(" -X %s", request.getMethod()));
-		}
-	}
-
-	private void writeHeaders(CliOperationRequest request, PrintWriter writer) {
-		for (Entry<String, List<String>> entry : request.getHeaders().entrySet()) {
-			for (String header : entry.getValue()) {
-				writer.print(String.format(" -H '%s: %s'", entry.getKey(), header));
+		Iterator<CurlLineGroup> it = lineBreaks.getLinesGroups().iterator();
+		while (it.hasNext()) {
+			CurlLineGroup lineGroup = it.next();
+			boolean groupHasContent = false;
+			for (CurlPart curlPart : lineGroup.getParts()) {
+				WriteAction action = map.get(curlPart);
+				if (action.hasContent(request)) {
+					groupHasContent = true;
+				}
+				setWriteActionState(action, lineBreaks);
+				writeActions.add(action);
+			}
+			if (it.hasNext() && groupHasContent) {
+				writeActions.add(new LineBreakWriteAction());
 			}
 		}
+
+		return writeActions;
 	}
 
-	private void writePartsIfNecessary(OperationRequest request, PrintWriter writer) {
-		for (OperationRequestPart part : request.getParts()) {
-			writer.printf(" -F '%s=", part.getName());
-			if (!StringUtils.hasText(part.getSubmittedFileName())) {
-				writer.append(part.getContentAsString());
-			}
-			else {
-				writer.printf("@%s", part.getSubmittedFileName());
-			}
-			if (part.getHeaders().getContentType() != null) {
-				writer.append(";type=")
-						.append(part.getHeaders().getContentType().toString());
-			}
-
-			writer.append("'");
+	private void setWriteActionState(WriteAction action, CurlLineBreakStrategy lineBreaks) {
+		if (action instanceof HeadersWriteAction) {
+			((HeadersWriteAction) action).setSplitHeader(lineBreaks.splitHeaders());
+		}
+		else if (action instanceof PartsWriteAction) {
+			((PartsWriteAction) action).setSplitParts(lineBreaks.splitMultiParts());
 		}
 	}
 
-	private void writeContent(CliOperationRequest request, PrintWriter writer) {
-		String content = request.getContentAsString();
-		if (StringUtils.hasText(content)) {
-			writer.print(String.format(" -d '%s'", content));
+	private Map<CurlPart, WriteAction> getWriteActionMap() {
+		Map<CurlPart, WriteAction> map = new HashMap<>();
+		map.put(CurlPart.SHOW_HEADER_OPTION, new ShowHeadersOptionWriteAction());
+		map.put(CurlPart.USER_OPTION, new UserOptionWriteAction());
+		map.put(CurlPart.HTTP_METHOD, new HttpMethodWriteAction());
+		map.put(CurlPart.HEADERS, new HeadersWriteAction());
+		map.put(CurlPart.MULTIPARTS, new PartsWriteAction());
+		map.put(CurlPart.CONTENT, new ContentWriteAction());
+		return map;
+	}
+
+	/**
+	 * A write action that should performed.
+	 */
+	private interface WriteAction {
+
+		/**
+		 * Writes the content to the writer.
+		 *
+		 * @param request the operation request.
+		 * @param writer the writer to write the data to.
+		 */
+		void write(CliOperationRequest request, PrintWriter writer);
+
+		/**
+		 * Check if the action produces any content. This is used to check whether
+		 * a new line should be appended. If there is content, a new line should
+		 * be appended after its group.
+		 *
+		 * @return true if the action produces any content, otherwise false.
+		 */
+		boolean hasContent(CliOperationRequest request);
+	}
+
+	/**
+	 * Abstract write action that defaults to returning true for whether the
+	 * writer produces any content.
+	 */
+	private abstract class AbstractWriteAction implements WriteAction {
+
+		@Override
+		public boolean hasContent(CliOperationRequest request) {
+			return true;
 		}
-		else if (!request.getParts().isEmpty()) {
-			for (Entry<String, List<String>> entry : request.getParameters().entrySet()) {
-				for (String value : entry.getValue()) {
-					writer.print(String.format(" -F '%s=%s'", entry.getKey(), value));
+	}
+
+	/**
+	 * A write action to write a line break with a {@code /} character.
+	 */
+	private final class LineBreakWriteAction extends AbstractWriteAction {
+
+		@Override
+		public void write(CliOperationRequest request, PrintWriter writer) {
+			writer.println(" \\");
+		}
+	}
+
+	/**
+	 * A write action to write the {@code -i} switch to show headers.
+	 */
+	private final class ShowHeadersOptionWriteAction extends AbstractWriteAction {
+
+		@Override
+		public void write(CliOperationRequest request, PrintWriter writer) {
+			writer.print("-i");
+		}
+	}
+
+	/**
+	 * A write action to write the user authentication.
+	 */
+	private final class UserOptionWriteAction extends AbstractWriteAction {
+
+		@Override
+		public void write(CliOperationRequest request, PrintWriter writer) {
+			String credentials = request.getBasicAuthCredentials();
+			if (credentials != null) {
+				writer.print(String.format(" -u '%s'", credentials));
+			}
+		}
+
+		@Override
+		public boolean hasContent(CliOperationRequest request) {
+			return request.getBasicAuthCredentials() != null;
+		}
+	}
+
+	/**
+	 * A write action that writes the HTTP method.
+	 */
+	private final class HttpMethodWriteAction extends AbstractWriteAction {
+
+		@Override
+		public void write(CliOperationRequest request, PrintWriter writer) {
+			if (!HttpMethod.GET.equals(request.getMethod())) {
+				writer.print(String.format(" -X %s", request.getMethod()));
+			}
+		}
+
+		@Override
+		public boolean hasContent(CliOperationRequest request) {
+			return !HttpMethod.GET.equals(request.getMethod());
+		}
+	}
+
+	/**
+	 * A write action that writes the request headers.
+	 */
+	private final class HeadersWriteAction extends AbstractWriteAction {
+
+		private boolean splitHeaders;
+
+		void setSplitHeader(boolean splitHeaders) {
+			this.splitHeaders = splitHeaders;
+		}
+
+		@Override
+		public void write(CliOperationRequest request, PrintWriter writer) {
+			Iterator<Entry<String, List<String>>> it = request.getHeaders().entrySet().iterator();
+			Entry<String, List<String>> entry;
+			while (it.hasNext()) {
+				entry = it.next();
+				Iterator<String> headerIt = entry.getValue().iterator();
+				String header;
+				while (headerIt.hasNext()) {
+					header = headerIt.next();
+					writer.print(String.format(" -H '%s: %s'", entry.getKey(), header));
+					if (this.splitHeaders && (it.hasNext() || headerIt.hasNext())) {
+						writer.println(" \\");
+					}
 				}
 			}
 		}
-		else if (request.isPutOrPost()) {
-			writeContentUsingParameters(request, writer);
+
+		@Override
+		public boolean hasContent(CliOperationRequest request) {
+			return !request.getHeaders().isEmpty();
 		}
 	}
 
-	private void writeContentUsingParameters(CliOperationRequest request,
-			PrintWriter writer) {
-		Parameters uniqueParameters = request.getUniqueParameters();
-		String queryString = uniqueParameters.toQueryString();
-		if (StringUtils.hasText(queryString)) {
-			writer.print(String.format(" -d '%s'", queryString));
+	/**
+	 * A write action that writes the multipart parts.
+	 */
+	private final class PartsWriteAction extends AbstractWriteAction {
+
+		private boolean splitParts;
+
+		void setSplitParts(boolean splitParts) {
+			this.splitParts = splitParts;
+		}
+
+		@Override
+		public void write(CliOperationRequest request, PrintWriter writer) {
+			Iterator<OperationRequestPart> it = request.getParts().iterator();
+			while (it.hasNext()) {
+				OperationRequestPart part = it.next();
+				writer.printf(" -F '%s=", part.getName());
+				if (!StringUtils.hasText(part.getSubmittedFileName())) {
+					writer.append(part.getContentAsString());
+				}
+				else {
+					writer.printf("@%s", part.getSubmittedFileName());
+				}
+				if (part.getHeaders().getContentType() != null) {
+					writer.append(";type=")
+							.append(part.getHeaders().getContentType().toString());
+				}
+
+				writer.append("'");
+				if (this.splitParts && it.hasNext()) {
+					writer.println(" \\");
+				}
+			}
+		}
+
+		@Override
+		public boolean hasContent(CliOperationRequest request) {
+			return !request.getParts().isEmpty();
 		}
 	}
 
+	/**
+	 * A write action that writes the request entity content.
+	 */
+	private final class ContentWriteAction extends AbstractWriteAction {
+
+		@Override
+		public void write(CliOperationRequest request, PrintWriter writer) {
+			String content = request.getContentAsString();
+			if (StringUtils.hasText(content)) {
+				writer.print(String.format(" -d '%s'", content));
+			}
+			else if (!request.getParts().isEmpty()) {
+				for (Entry<String, List<String>> entry : request.getParameters().entrySet()) {
+					for (String value : entry.getValue()) {
+						writer.print(String.format(" -F '%s=%s'", entry.getKey(), value));
+					}
+				}
+			}
+			else if (request.isPutOrPost()) {
+				writeContentUsingParameters(request, writer);
+			}
+		}
+
+		@Override
+		public boolean hasContent(CliOperationRequest request) {
+			String content = request.getContentAsString();
+			return StringUtils.hasText(content)
+					|| !request.getParts().isEmpty()
+					|| request.isPutOrPost();
+		}
+
+		private void writeContentUsingParameters(CliOperationRequest request, PrintWriter writer) {
+			Parameters uniqueParameters = request.getUniqueParameters();
+			String queryString = uniqueParameters.toQueryString();
+			if (StringUtils.hasText(queryString)) {
+				writer.print(String.format(" -d '%s'", queryString));
+			}
+		}
+	}
 }

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/cli/CurlLineBreakStrategiesTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/cli/CurlLineBreakStrategiesTests.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.cli;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.springframework.restdocs.AbstractSnippetTests;
+import org.springframework.restdocs.templates.TemplateFormat;
+
+/**
+ * Tests for {@link CurlLineBreakStrategies} and their interactions with
+ * {@link CurlRequestSnippet}.
+ *
+ * @author Paul Samsotha
+ */
+@RunWith(Parameterized.class)
+public class CurlLineBreakStrategiesTests extends AbstractSnippetTests {
+
+	private static final String SEP = System.getProperty("line.separator");
+
+	public CurlLineBreakStrategiesTests(String name, TemplateFormat templateFormat) {
+		super(name, templateFormat);
+	}
+
+	@Test
+	public void defaultNoLineBreaks() throws Exception {
+		String expected = "$ curl 'http://localhost/foo' -i -X POST"
+				+ " -H 'X-Header-One: ONE'"
+				+ " -d 'Some Content'";
+		this.snippet.expectCurlRequest("default-no-breaks")
+				.withContents(codeBlock("bash").content(expected));
+		new CurlRequestSnippet().document(
+				operationBuilder("default-no-breaks")
+				.attribute(CurlLineBreakStrategy.class.getName(),
+						CurlLineBreakStrategies.none())
+				.request("http://localhost/foo")
+				.method("POST")
+				.header("X-Header-One", "ONE")
+				.content("Some Content")
+				.build());
+	}
+
+	@Test
+	public void headersOnlyLineBreaks() throws Exception {
+		String expected = "$ curl 'http://localhost/foo' -i -X POST -d 'Some Content' \\"
+				+ SEP
+				+ " -H 'X-Header-One: ONE' \\" + SEP
+				+ " -H 'X-Header-Two: TWO' \\" + SEP
+				+ " -H 'X-Header-Three: THREE'";
+		this.snippet.expectCurlRequest("headers-only-breaks")
+				.withContents(codeBlock("bash").content(expected));
+		new CurlRequestSnippet().document(
+				operationBuilder("headers-only-breaks")
+				.attribute(CurlLineBreakStrategy.class.getName(),
+						CurlLineBreakStrategies.headersOnly())
+				.request("http://localhost/foo")
+				.method("POST")
+				.header("X-Header-One", "ONE")
+				.header("X-Header-Two", "TWO")
+				.header("X-Header-Three", "THREE")
+				.content("Some Content")
+				.build());
+	}
+
+	@Test
+	public void partsOnlyLineBreaks() throws Exception {
+		String expected = "$ curl 'http://localhost/foo' -i -X POST -H 'X-Header-One: ONE' \\"
+				+ SEP
+				+ " -F 'field1=Field1Data' \\" + SEP
+				+ " -F 'field2=Field2Data'";
+		this.snippet.expectCurlRequest("parts-only-breaks")
+				.withContents(codeBlock("bash").content(expected));
+		new CurlRequestSnippet().document(
+				operationBuilder("parts-only-breaks")
+				.attribute(CurlLineBreakStrategy.class.getName(),
+						CurlLineBreakStrategies.partsOnly())
+				.request("http://localhost/foo")
+				.method("POST")
+				.header("X-Header-One", "ONE")
+				.part("field1", "Field1Data".getBytes())
+				.and()
+				.part("field2", "Field2Data".getBytes())
+				.build());
+	}
+
+	@Test
+	public void headersAndPartsLineBreaks() throws Exception {
+		String expected = "$ curl 'http://localhost/foo' -i -X POST \\" + SEP
+				+ " -H 'X-Header-One: ONE' \\" + SEP
+				+ " -H 'X-Header-Two: TWO' \\" + SEP
+				+ " -H 'X-Header-Three: THREE' \\" + SEP
+				+ " -F 'field1=Field1Data' \\" + SEP
+				+ " -F 'field2=Field2Data'";
+		this.snippet.expectCurlRequest("headers-and-parts-breaks")
+				.withContents(codeBlock("bash").content(expected));
+		new CurlRequestSnippet().document(
+				operationBuilder("headers-and-parts-breaks")
+				.attribute(CurlLineBreakStrategy.class.getName(),
+						CurlLineBreakStrategies.headersAndParts())
+				.request("http://localhost/foo")
+				.method("POST")
+				.header("X-Header-One", "ONE")
+				.header("X-Header-Two", "TWO")
+				.header("X-Header-Three", "THREE")
+				.part("field1", "Field1Data".getBytes())
+				.and()
+				.part("field2", "Field2Data".getBytes())
+				.build());
+	}
+
+	@Test
+	public void contentOnlyLineBreaks() throws Exception {
+		String expected = "$ curl 'http://localhost/foo' -i -X POST -H 'X-Header-One: ONE' \\"
+				+ SEP
+				+ " -d 'a=aplha&b=bravo'";
+		this.snippet.expectCurlRequest("content-only-break")
+				.withContents(codeBlock("bash").content(expected));
+		new CurlRequestSnippet().document(
+				operationBuilder("content-only-break")
+				.attribute(CurlLineBreakStrategy.class.getName(),
+						CurlLineBreakStrategies.contentOnly())
+				.request("http://localhost/foo")
+				.method("POST")
+				.header("X-Header-One", "ONE")
+				.param("a", "aplha")
+				.param("b", "bravo")
+				.build());
+	}
+
+	@Test
+	public void headersAndContentLineBreaks() throws Exception {
+		String expected = "$ curl 'http://localhost/foo' -i -X POST \\" + SEP
+				+ " -H 'X-Header-One: ONE' \\" + SEP
+				+ " -H 'X-Header-Two: TWO' \\" + SEP
+				+ " -H 'X-Header-Three: THREE' \\" + SEP
+				+ " -d 'Some Content'";
+		this.snippet.expectCurlRequest("headers-and-content-breaks")
+				.withContents(codeBlock("bash").content(expected));
+		new CurlRequestSnippet().document(
+				operationBuilder("headers-and-content-breaks")
+				.attribute(CurlLineBreakStrategy.class.getName(),
+						CurlLineBreakStrategies.headersAndContent())
+				.request("http://localhost/foo")
+				.method("POST")
+				.header("X-Header-One", "ONE")
+				.header("X-Header-Two", "TWO")
+				.header("X-Header-Three", "THREE")
+				.content("Some Content")
+				.build());
+	}
+
+	@Test
+	public void customPartsBeforeHeaderBreaks() throws Exception {
+		String expected = "$ curl 'http://localhost/foo' -i -X POST \\" + SEP
+				+ " -F 'field1=Field1Data' \\" + SEP
+				+ " -F 'field2=Field2Data' \\" + SEP
+				+ " -H 'X-Header-One: ONE' \\" + SEP
+				+ " -H 'X-Header-Two: TWO' \\" + SEP
+				+ " -H 'X-Header-Three: THREE'";
+		this.snippet.expectCurlRequest("custom-parts-before-headers-breaks")
+				.withContents(codeBlock("bash").content(expected));
+		new CurlRequestSnippet().document(
+				operationBuilder("custom-parts-before-headers-breaks")
+				.attribute(CurlLineBreakStrategy.class.getName(),
+						new PartsAndHeadersCurlLineBreakStrategy())
+				.request("http://localhost/foo")
+				.method("POST")
+				.header("X-Header-One", "ONE")
+				.header("X-Header-Two", "TWO")
+				.header("X-Header-Three", "THREE")
+				.part("field1", "Field1Data".getBytes())
+				.and()
+				.part("field2", "Field2Data".getBytes())
+				.build());
+	}
+
+	@Test
+	public void customContentBeforeHeadersBreaks() throws Exception {
+		String expected = "$ curl 'http://localhost/foo' -i -X POST \\" + SEP
+				+ " -d 'Some Content' \\" + SEP
+				+ " -H 'X-Header-One: ONE' \\" + SEP
+				+ " -H 'X-Header-Two: TWO' \\" + SEP
+				+ " -H 'X-Header-Three: THREE'";
+		this.snippet.expectCurlRequest("custom-content-before-headers-breaks")
+				.withContents(codeBlock("bash").content(expected));
+		new CurlRequestSnippet().document(
+				operationBuilder("custom-content-before-headers-breaks")
+				.attribute(CurlLineBreakStrategy.class.getName(),
+						new ContentThenHeadersCurlLineBreakStrategy())
+				.request("http://localhost/foo")
+				.method("POST")
+				.header("X-Header-One", "ONE")
+				.header("X-Header-Two", "TWO")
+				.header("X-Header-Three", "THREE")
+				.content("Some Content")
+				.build());
+	}
+
+	private static final class PartsAndHeadersCurlLineBreakStrategy
+			implements CurlLineBreakStrategy {
+
+		@Override
+		public List<CurlLineGroup> getLinesGroups() {
+			CurlLineGroup allButHeaders = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
+					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
+					CurlPart.CONTENT);
+			CurlLineGroup headers = new CurlLineGroup(CurlPart.HEADERS);
+			CurlLineGroup multiparts = new CurlLineGroup(CurlPart.MULTIPARTS);
+			return Arrays.asList(allButHeaders, multiparts, headers);
+		}
+
+		@Override
+		public boolean splitHeaders() {
+			return true;
+		}
+
+		@Override
+		public boolean splitMultiParts() {
+			return true;
+		}
+	}
+
+	private static final class ContentThenHeadersCurlLineBreakStrategy
+			implements CurlLineBreakStrategy {
+
+		@Override
+		public List<CurlLineGroup> getLinesGroups() {
+			CurlLineGroup allButHeaders = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
+					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
+					CurlPart.MULTIPARTS);
+			CurlLineGroup headers = new CurlLineGroup(CurlPart.HEADERS);
+			CurlLineGroup content = new CurlLineGroup(CurlPart.CONTENT);
+			return Arrays.asList(allButHeaders, content, headers);
+		}
+
+		@Override
+		public boolean splitHeaders() {
+			return true;
+		}
+
+		@Override
+		public boolean splitMultiParts() {
+			return true;
+		}
+	}
+}

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/cli/CurlLineBreakStrategiesTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/cli/CurlLineBreakStrategiesTests.java
@@ -219,7 +219,7 @@ public class CurlLineBreakStrategiesTests extends AbstractSnippetTests {
 			implements CurlLineBreakStrategy {
 
 		@Override
-		public List<CurlLineGroup> getLinesGroups() {
+		public List<CurlLineGroup> getLineGroups() {
 			CurlLineGroup allButHeaders = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
 					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
 					CurlPart.CONTENT);
@@ -243,7 +243,7 @@ public class CurlLineBreakStrategiesTests extends AbstractSnippetTests {
 			implements CurlLineBreakStrategy {
 
 		@Override
-		public List<CurlLineGroup> getLinesGroups() {
+		public List<CurlLineGroup> getLineGroups() {
 			CurlLineGroup allButHeaders = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
 					CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
 					CurlPart.MULTIPARTS);


### PR DESCRIPTION
To add support for cURL snippets with line breaks, a few classes were added:
- `CurlPart` - represents a part of a cURL command
- `CurlLineGroup` - a group of cURL curl parts that make up a line
- `CurlLineBreakStrategy` - a strategy for how lines should
  be broken up
- `CurlLineBreakStrategies` - factory methods for strategies

To support configurability, the `CurlRequestSnippet` has been almost completely redone. Methods that originally wrote out a part of a command, have been abstracted into a into a class, for which instances can be mapped to the according `CurlPart`. The original code to write snippets was

``` java
private String getOptions(Operation operation) {
    StringWriter command = new StringWriter();
    PrintWriter printer = new PrintWriter(command);
    writeIncludeHeadersInOutputOption(printer);
    CliOperationRequest request = new CliOperationRequest(operation.getRequest());
    writeUserOptionIfNecessary(request, printer);
    writeHttpMethodIfNecessary(request, printer);
    writeHeaders(request, printer);
    writePartsIfNecessary(request, printer);
    writeContent(request, printer);

    return command.toString();
}
```

Each one of those `writeXxx` methods have been abstracted to a `WriteAction` class, that can be mapped to a `CurlPart`. How the cURL parts are grouped are through `CurlLineGroup`s. For example, if we have the following strategy implementation

``` java
CurlLineGroup optionsAndMethod = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
        CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
        CurlPart.MULTIPARTS);
CurlLineGroup headers = new CurlLineGroup(CurlPart.HEADERS);
CurlLineGroup content = new CurlLineGroup(CurlPart.CONTENT);
return Arrays.asList(optionsAndMethod, headers, content);
```

we have three line groups, each of which will be in a separate line. The order of the parts can also be switched around. Also, as headers and parts have multiple parts, we can also separate those individual parts on separate lines, by returning true or false on the following methods of the strategy interface

``` java
@Override
public boolean splitHeaders() {
    return true;
}

@Override
public boolean splitMultiParts() {
    return false;
}
```

So with the following complete implementation

``` java
private static final class HeadersAndContentCurlLineBreakStrategy
        implements CurlLineBreakStrategy {

    @Override
    public List<CurlLineGroup> getLinesGroups() {
        CurlLineGroup optionsAndMethod = new CurlLineGroup(CurlPart.SHOW_HEADER_OPTION,
                CurlPart.USER_OPTION, CurlPart.HTTP_METHOD,
                CurlPart.MULTIPARTS);
        CurlLineGroup headers = new CurlLineGroup(CurlPart.HEADERS);
        CurlLineGroup content = new CurlLineGroup(CurlPart.CONTENT);
        return Arrays.asList(optionsAndMethod, headers, content);
    }

    @Override
    public boolean splitHeaders() {
        return true;
    }

    @Override
    public boolean splitMultiParts() {
        return false;
    }
}
```

we would get the following output

``` bash
$ curl 'http://localhost/foo' -i -X POST \
   -H 'X-Header-One: ONE' \
   -H 'X-Header-Two: TWO' \
   -H 'X-Header-Three: THREE' \
   -d 'Some Content'
```

With this infrastructure in place, it is easy for the user to implement their own strategy, if none of the ones available suit their requirements.

The default strategy is to use no line breaks, so specifying none will be business as usual. There are a few other strategy implementations. You can see them in the `CurlLineBreakStrategies` class, for which there are the following static factory methods

``` java
none()
headersOnly()
partsOnly()
headersAndParts()
contentOnly()
headersAndContent()
```

See the javadoc for example output for each of those strategies.

Strategies can be plugged in simply by specifying an operation attribute key `CurlLineBreakStrategy.class.getName()`, with the value being an implementation of the `CurlLineBreakStrategy` interface. You can use one of the above factory methods, or just provide your own implementation.
