### PR TITLE
Remove unnecessary Host header set in UriModifyingOperationPreprocessor

### DIFF
--- a/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured/operation/preprocess/UriModifyingOperationPreprocessor.java
+++ b/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured/operation/preprocess/UriModifyingOperationPreprocessor.java
@@ -126,10 +126,8 @@ public final class UriModifyingOperationPreprocessor implements OperationPreproc
 		if (this.scheme != null) {
 			uriBuilder.scheme(this.scheme);
 		}
-		HttpHeaders modifiedHeaders = modify(request.getHeaders());
 		if (this.host != null) {
 			uriBuilder.host(this.host);
-			modifiedHeaders.set(HttpHeaders.HOST, this.host);
 		}
 		if (this.port != null) {
 			if (StringUtils.hasText(this.port)) {
@@ -140,6 +138,7 @@ public final class UriModifyingOperationPreprocessor implements OperationPreproc
 			}
 		}
 		URI modifiedUri = uriBuilder.build(true).toUri();
+		HttpHeaders modifiedHeaders = modify(request.getHeaders());
 		modifiedHeaders.set(HttpHeaders.HOST, modifiedUri.getHost()
 				+ (modifiedUri.getPort() == -1 ? "" : ":" + modifiedUri.getPort()));
 		return this.contentModifyingDelegate.preprocess(


### PR DESCRIPTION
The `Host` header set value will be replaced below without using it, so it looks unnecessary.