### PR TITLE
Add extension points to TemplatedSnippet for output file locations

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/snippet/TemplatedSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/snippet/TemplatedSnippet.java
@@ -59,14 +59,36 @@ public abstract class TemplatedSnippet implements Snippet {
 				.getAttributes().get(RestDocumentationContext.class.getName());
 		WriterResolver writerResolver = (WriterResolver) operation.getAttributes()
 				.get(WriterResolver.class.getName());
-		try (Writer writer = writerResolver.resolve(operation.getName(), this.snippetName,
-				context)) {
+		try (Writer writer = writerResolver.resolve(getOutputDir(operation),
+				getFileName(operation), context)) {
 			Map<String, Object> model = createModel(operation);
 			model.putAll(this.attributes);
 			TemplateEngine templateEngine = (TemplateEngine) operation.getAttributes()
 					.get(TemplateEngine.class.getName());
 			writer.append(templateEngine.compileTemplate(this.snippetName).render(model));
 		}
+	}
+
+	/**
+	 * Compute the file name for the snippet output (minus the extension). Default is
+	 * simply the snippet name.
+	 *
+	 * @param operation the current operation
+	 * @return the base name of the snippet file
+	 */
+	protected String getFileName(Operation operation) {
+		return getSnippetName();
+	}
+
+	/**
+	 * Compute the output directory for the snippet (relative to the global output
+	 * directory). Default is the operation name.
+	 *
+	 * @param operation the current operation
+	 * @return the name of a directory to write the snippet
+	 */
+	protected String getOutputDir(Operation operation) {
+		return operation.getName();
 	}
 
 	/**


### PR DESCRIPTION
This is a useful base class for custom snippets but it only knows
how to put the output in one place (operation.name/snippetName).
This change extracts those two locations (base dir and file name)
into protected methods without changing the existing behaviour.