### PR TITLE
Provide default port / scheme information in documentation

### DIFF
--- a/docs/src/docs/asciidoc/configuration.adoc
+++ b/docs/src/docs/asciidoc/configuration.adoc
@@ -34,6 +34,10 @@ to change one or more of the defaults to suit your needs:
 include::{examples-dir}/com/example/mockmvc/CustomUriConfiguration.java[tags=custom-uri-configuration]
 ----
 
+NOTE: If the port is set to default according to the configured scheme, i.e.,
+port 80 for HTTP and port 443 for HTTPS, the ports will be omitted in the snippets
+that contain the generated URI.
+
 TIP: To configure a request's context path, use the `contextPath` method on
 `MockHttpServletRequestBuilder`.
 


### PR DESCRIPTION
Add a note about default ports 80 and 443 in combination with http or https scheme.
Fixes gh-325

Same one as the https://github.com/spring-projects/spring-restdocs/pull/328 but now with `1.1.x` as base branch.