### PR TITLE
Include cookies in response snippets

### DIFF
--- a/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/MockMvcResponseConverter.java
+++ b/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/MockMvcResponseConverter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.restdocs.mockmvc;
 
+import javax.servlet.http.Cookie;
+
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -45,7 +47,54 @@ class MockMvcResponseConverter implements ResponseConverter<MockHttpServletRespo
 				headers.add(headerName, value);
 			}
 		}
+
+		if (response.getCookies() != null && !headers.containsKey(HttpHeaders.SET_COOKIE)) {
+			for (Cookie cookie : response.getCookies()) {
+				headers.add(HttpHeaders.SET_COOKIE, generateSetCookieHeader(cookie));
+			}
+		}
+
 		return headers;
+	}
+
+	private String generateSetCookieHeader(Cookie cookie) {
+		StringBuilder header = new StringBuilder();
+
+		header.append(cookie.getName());
+		header.append('=');
+
+		String value = cookie.getValue();
+		if (value != null && value.length() > 0) {
+			header.append(value);
+		}
+
+		int maxAge = cookie.getMaxAge();
+		if (maxAge > -1) {
+			header.append(";Max-Age=");
+			header.append(maxAge);
+		}
+
+		String domain = cookie.getDomain();
+		if (domain != null && domain.length() > 0) {
+			header.append(";domain=");
+			header.append(domain);
+		}
+
+		String path = cookie.getPath();
+		if (path != null && path.length() > 0) {
+			header.append(";path=");
+			header.append(path);
+		}
+
+		if (cookie.getSecure()) {
+			header.append(";Secure");
+		}
+
+		if (cookie.isHttpOnly()) {
+			header.append(";HttpOnly");
+		}
+
+		return header.toString();
 	}
 
 }

--- a/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcResponseConverterTests.java
+++ b/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcResponseConverterTests.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.mockmvc;
+
+import java.util.Collections;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.restdocs.operation.OperationResponse;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link MockMvcResponseConverter}.
+ *
+ * @author Tomasz Kopczynski
+ */
+public class MockMvcResponseConverterTests {
+
+	private final MockMvcResponseConverter factory = new MockMvcResponseConverter();
+
+	@Test
+	public void httpResponse() {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		response.setStatus(HttpServletResponse.SC_OK);
+
+		OperationResponse operationResponse = this.factory.convert(response);
+
+		assertThat(operationResponse.getStatus(), is(HttpStatus.OK));
+	}
+
+	@Test
+	public void responseWithCookie() {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		response.setStatus(HttpServletResponse.SC_OK);
+
+		Cookie cookie = new Cookie("name", "value");
+		cookie.setDomain("localhost");
+		cookie.setHttpOnly(true);
+
+		response.addCookie(cookie);
+
+		OperationResponse operationResponse = this.factory.convert(response);
+
+		assertThat(operationResponse.getHeaders().size(), is(1));
+		assertTrue(operationResponse.getHeaders().containsKey(HttpHeaders.SET_COOKIE));
+		assertThat(operationResponse.getHeaders().get(HttpHeaders.SET_COOKIE), equalTo(Collections.singletonList("name=value;domain=localhost;HttpOnly")));
+	}
+}

--- a/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcRestDocumentationIntegrationTests.java
+++ b/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcRestDocumentationIntegrationTests.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
 
 import org.junit.After;
 import org.junit.Before;
@@ -366,6 +367,24 @@ public class MockMvcRestDocumentationIntegrationTests {
 	}
 
 	@Test
+	public void responseWithSetCookie() throws Exception {
+		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
+				.apply(documentationConfiguration(this.restDocumentation)).build();
+
+		mockMvc.perform(get("/set-cookie"))
+				.andExpect(status().isOk())
+				.andDo(document("set-cookie",
+						responseHeaders(headerWithName(HttpHeaders.SET_COOKIE).description("set-cookie"))));
+
+		assertThat(
+				new File("build/generated-snippets/set-cookie/http-response.adoc"),
+				is(snippet(asciidoctor())
+						.withContents(
+								httpResponse(asciidoctor(), HttpStatus.OK)
+										.header(HttpHeaders.SET_COOKIE, "name=value;domain=localhost;HttpOnly"))));
+	}
+
+	@Test
 	public void parameterizedOutputDirectory() throws Exception {
 		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
 				.apply(documentationConfiguration(this.restDocumentation)).build();
@@ -599,6 +618,15 @@ public class MockMvcRestDocumentationIntegrationTests {
 		@RequestMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 		public void upload() {
 
+		}
+
+		@RequestMapping("/set-cookie")
+		public void setCookie(HttpServletResponse response) {
+			Cookie cookie = new Cookie("name", "value");
+			cookie.setDomain("localhost");
+			cookie.setHttpOnly(true);
+
+			response.addCookie(cookie);
 		}
 
 	}

--- a/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured/RestAssuredRestDocumentationIntegrationTests.java
+++ b/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured/RestAssuredRestDocumentationIntegrationTests.java
@@ -270,6 +270,26 @@ public class RestAssuredRestDocumentationIntegrationTests {
 	}
 
 	@Test
+	public void responseWithCookie() {
+		given().port(tomcat.getPort())
+				.filter(documentationConfiguration(this.restDocumentation))
+				.filter(document("set-cookie",
+						preprocessResponse(removeHeaders(HttpHeaders.DATE, HttpHeaders.CONTENT_TYPE))))
+				.get("/set-cookie").then().statusCode(200);
+		assertExpectedSnippetFilesExist(new File("build/generated-snippets/set-cookie"),
+				"http-request.adoc", "http-response.adoc", "curl-request.adoc");
+
+		assertThat(
+				new File("build/generated-snippets/set-cookie/http-response.adoc"),
+				is(snippet(asciidoctor())
+					.withContents(httpResponse(asciidoctor(), HttpStatus.OK)
+						.header(HttpHeaders.SET_COOKIE, "name=value;domain=localhost;HttpOnly")
+					)
+				)
+		);
+	}
+
+	@Test
 	public void preprocessedRequest() throws Exception {
 		Pattern pattern = Pattern.compile("(\"alpha\")");
 		given().port(tomcat.getPort())

--- a/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured/TomcatServer.java
+++ b/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured/TomcatServer.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -51,6 +52,8 @@ class TomcatServer extends ExternalResource {
 		Context context = this.tomcat.addContext("/", null);
 		this.tomcat.addServlet("/", "test", new TestServlet());
 		context.addServletMappingDecoded("/", "test");
+		this.tomcat.addServlet("/", "set-cookie", new CookiesServlet());
+		context.addServletMappingDecoded("/set-cookie", "set-cookie");
 		this.tomcat.start();
 		this.port = this.tomcat.getConnector().getLocalPort();
 	}
@@ -102,6 +105,21 @@ class TomcatServer extends ExternalResource {
 			response.flushBuffer();
 		}
 
+	}
+
+	/**
+	 * {@link HttpServlet} used to handle cookies-related requests in the tests.
+	 */
+	private static final class CookiesServlet extends HttpServlet {
+
+		@Override
+		protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+			Cookie cookie = new Cookie("name", "value");
+			cookie.setDomain("localhost");
+			cookie.setHttpOnly(true);
+
+			resp.addCookie(cookie);
+		}
 	}
 
 }


### PR DESCRIPTION
This PR adds response cookies handling for Mock MVC and a few tests for handling `Set-Cookie` header for Rest Assured.

Closes gh-305