### PR TITLE
Set SnippetConfiguration class to public

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/config/SnippetConfiguration.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/config/SnippetConfiguration.java
@@ -24,22 +24,38 @@ import org.springframework.restdocs.templates.TemplateFormat;
  * @author Andy Wilkinson
  * @since 1.1.0
  */
-class SnippetConfiguration {
+public class SnippetConfiguration {
 
 	private final String encoding;
 
 	private final TemplateFormat format;
 
-	SnippetConfiguration(String encoding, TemplateFormat templateFormat) {
+	/**
+	 * Creates a new Snippet Configuration with provided encoding and template format.
+	 *
+	 * @param encoding encoding to use
+	 * @param templateFormat template format to use
+	 */
+	public SnippetConfiguration(String encoding, TemplateFormat templateFormat) {
 		this.encoding = encoding;
 		this.format = templateFormat;
 	}
 
-	String getEncoding() {
+	/**
+	 * Returns the encoding.
+	 *
+	 * @return encoding
+	 */
+	public String getEncoding() {
 		return this.encoding;
 	}
 
-	TemplateFormat getTemplateFormat() {
+	/**
+	 * Returns the template format.
+	 *
+	 * @return template format
+	 */
+	public TemplateFormat getTemplateFormat() {
 		return this.format;
 	}
 


### PR DESCRIPTION
In our project https://github.com/ScaCap/spring-auto-restdocs we sometimes write multi-line values inside tables in snippets. We need to discover the templateFormat which will be used during writing such snippet, so that we can output proper newline character: ` +\n` in AsciiDoc and `<br>` in Markdown.
Therefore we need this class to be public, so we can extract this information by getting it from `org.springframework.restdocs.operation.Operation` attributes.

If this is not acceptable, we need another way of getting template format information from the Operation to use it inside the snippet.