### PR TITLE
Fix uncaught MissingResourceException in ResourceBundleConstraintDescriptionResolver when a contraint is resolved that isn't found in DefaultConstraintDescriptions.properties

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/constraints/ConstraintDescriptionResolver.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/constraints/ConstraintDescriptionResolver.java
@@ -28,7 +28,7 @@ public interface ConstraintDescriptionResolver {
 	 * Resolves the description for the given {@code constraint}.
 	 *
 	 * @param constraint the constraint
-	 * @return the description
+	 * @return the description or null if no description is available
 	 */
 	String resolveDescription(Constraint constraint);
 }

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/constraints/ConstraintDescriptions.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/constraints/ConstraintDescriptions.java
@@ -100,7 +100,10 @@ public class ConstraintDescriptions {
 				.resolveForProperty(property, this.clazz);
 		List<String> descriptions = new ArrayList<>();
 		for (Constraint constraint : constraints) {
-			descriptions.add(this.descriptionResolver.resolveDescription(constraint));
+			String description = this.descriptionResolver.resolveDescription(constraint);
+			if (description != null) {
+				descriptions.add(this.descriptionResolver.resolveDescription(constraint));
+			}
 		}
 		Collections.sort(descriptions);
 		return descriptions;

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/constraints/ResourceBundleConstraintDescriptionResolver.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/constraints/ResourceBundleConstraintDescriptionResolver.java
@@ -154,7 +154,12 @@ public class ResourceBundleConstraintDescriptionResolver
 		catch (MissingResourceException ex) {
 			// Continue and return default description, if available
 		}
-		return this.defaultDescriptions.getString(key);
+		try {
+			return this.defaultDescriptions.getString(key);
+		}
+		catch (MissingResourceException ex) {
+			return null;
+		}
 	}
 
 	private static final class ConstraintPlaceholderResolver


### PR DESCRIPTION
When an attempt is made to resolve a contraint description for a constraint that isn't listed in DefaultConstraintDescriptions.properties (such as the new org.hibernate.validator.constraints.time.DurationMin), ResourceBundleConstraintDescriptionResolvergetDescription will throw MissingResourceException.

This issue was caused when implementing #42