### PR TITLE
Extend the default snippets list in documentation

### DIFF
--- a/docs/src/docs/asciidoc/configuration.adoc
+++ b/docs/src/docs/asciidoc/configuration.adoc
@@ -96,6 +96,8 @@ Four snippets are produced by default:
 - `http-request`
 - `http-response`
 - `httpie-request`
+- `request-body`
+- `response-body`
 
 You can change the default snippet configuration during setup using the
 `RestDocumentationConfigurer` API. For example, to only produce the `curl-request`


### PR DESCRIPTION
Adding two additional snippets to the default snippets list in documentation