### PR TITLE
Data REST sample fails to build due without a prior mvn install due to missing <pluginRepository> declaration

### DIFF
--- a/samples/rest-notes-spring-data-rest/pom.xml
+++ b/samples/rest-notes-spring-data-rest/pom.xml
@@ -117,6 +117,18 @@
 		</plugins>
 	</build>
 
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>spring-snapshots</id>
+			<name>Spring snapshots</name>
+			<url>https://repo.spring.io/libs-snapshot</url>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<repositories>
 		<repository>
 			<id>spring-snapshots</id>


### PR DESCRIPTION
The build of rest-notes-spring-data-rest failed because the spring-restdocs-asciidoctor artifact
is (of course) missing in the sonatype repository.
Maven does not use the repository definition to look up a dependency for a plugin but needs the
pluginRepositories configuration.

Fixes gh-#382