### PR TITLE
Support text/xml & application/rss+xml media types

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/AbstractFieldsSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/AbstractFieldsSnippet.java
@@ -221,7 +221,7 @@ public abstract class AbstractFieldsSnippet extends TemplatedSnippet {
 	private ContentHandler getContentHandler(byte[] content, MediaType contentType) {
 		try {
 			if (contentType != null
-					&& MediaType.APPLICATION_XML.isCompatibleWith(contentType)) {
+					&& isCompatibleWithXml(contentType)) {
 				return new XmlContentHandler(content);
 			}
 			else {
@@ -231,6 +231,12 @@ public abstract class AbstractFieldsSnippet extends TemplatedSnippet {
 		catch (IOException ex) {
 			throw new ModelCreationException(ex);
 		}
+	}
+
+	private boolean isCompatibleWithXml(MediaType contentType) {
+		return MediaType.APPLICATION_XML.isCompatibleWith(contentType) ||
+				MediaType.TEXT_XML.isCompatibleWith(contentType) ||
+				MediaType.APPLICATION_RSS_XML.isCompatibleWith(contentType);
 	}
 
 	private void validateFieldDocumentation(ContentHandler payloadHandler) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
@@ -226,7 +226,7 @@ public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
-	public void fieldWithExplictVariesType() throws IOException {
+	public void fieldWithExplicitVariesType() throws IOException {
 		this.snippets.expectResponseFields()
 				.withContents(tableWithHeader("Path", "Type", "Description").row("`a`",
 						"`Varies`", "one"));
@@ -238,7 +238,21 @@ public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
-	public void xmlResponseFields() throws IOException {
+	public void xmlResponseFieldsWithApplicationXml() throws IOException {
+		xml(MediaType.APPLICATION_XML_VALUE);
+	}
+
+	@Test
+	public void xmlResponseFieldsWithTextXml() throws IOException {
+		xml(MediaType.TEXT_XML_VALUE);
+	}
+
+	@Test
+	public void xmlResponseFieldsWithRssXml() throws IOException {
+		xml(MediaType.APPLICATION_RSS_XML_VALUE);
+	}
+
+	private void xml(String mediaType) throws IOException {
 		this.snippets.expectResponseFields()
 				.withContents(tableWithHeader("Path", "Type", "Description")
 						.row("`a/b`", "`b`", "one").row("`a/c`", "`c`", "two")
@@ -247,12 +261,12 @@ public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 				Arrays.asList(fieldWithPath("a/b").description("one").type("b"),
 						fieldWithPath("a/c").description("two").type("c"),
 						fieldWithPath("a").description("three").type("a")))
-								.document(
-										this.operationBuilder.response()
-												.content("<a><b>5</b><c>charlie</c></a>")
-												.header(HttpHeaders.CONTENT_TYPE,
-														MediaType.APPLICATION_XML_VALUE)
-										.build());
+				.document(
+						this.operationBuilder.response()
+								.content("<a><b>5</b><c>charlie</c></a>")
+								.header(HttpHeaders.CONTENT_TYPE,
+										mediaType)
+								.build());
 	}
 
 	@Test


### PR DESCRIPTION
This commit adds support to process two more content types.

See gh-393