### PR TITLE
Fix JSON field type resolution for nested array fields

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldPath.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldPath.java
@@ -17,7 +17,6 @@
 package org.springframework.restdocs.payload;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,7 +26,7 @@ import java.util.regex.Pattern;
  *
  * @author Andy Wilkinson
  * @author Jeremy Rickard
- *
+ * @author Minhyeok Jeong
  */
 final class JsonFieldPath {
 
@@ -41,8 +40,13 @@ final class JsonFieldPath {
 
 	private final List<String> segments;
 
+	/**
+	 * Whether this path indicates a specific value which is neither an array nor an
+	 * object.
+	 */
 	private final boolean precise;
 
+	/** Whether this path indicates an array. */
 	private final boolean array;
 
 	private JsonFieldPath(String rawPath, List<String> segments, boolean precise,
@@ -81,11 +85,9 @@ final class JsonFieldPath {
 		return ARRAY_INDEX_PATTERN.matcher(segment).matches();
 	}
 
-	static boolean matchesSingleValue(List<String> segments) {
-		Iterator<String> iterator = segments.iterator();
-		while (iterator.hasNext()) {
-			String next = iterator.next();
-			if ((isArraySegment(next) || isWildcardSegment(next)) && iterator.hasNext()) {
+	private static boolean matchesSingleValue(List<String> segments) {
+		for (String segment : segments) {
+			if (isArraySegment(segment) || isWildcardSegment(segment)) {
 				return false;
 			}
 		}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldProcessor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldProcessor.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * extracted and removed.
  *
  * @author Andy Wilkinson
- *
+ * @author Minhyeok Jeong
  */
 final class JsonFieldProcessor {
 
@@ -48,14 +48,15 @@ final class JsonFieldProcessor {
 
 			@Override
 			public void absent() {
-
 			}
 
 		});
+
 		if (matches.isEmpty()) {
 			throw new FieldDoesNotExistException(path);
 		}
-		if ((!path.isArray()) && path.isPrecise()) {
+
+		if (path.isPrecise()) {
 			return matches.get(0);
 		}
 		else {
@@ -73,7 +74,6 @@ final class JsonFieldProcessor {
 
 			@Override
 			public void absent() {
-
 			}
 
 		});
@@ -89,7 +89,6 @@ final class JsonFieldProcessor {
 
 			@Override
 			public void absent() {
-
 			}
 
 		});

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldTypeResolver.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldTypeResolver.java
@@ -23,6 +23,7 @@ import java.util.Map;
  * Resolves the type of a field in a JSON request or response payload.
  *
  * @author Andy Wilkinson
+ * @author Minhyeok Jeong
  */
 class JsonFieldTypeResolver {
 
@@ -31,7 +32,9 @@ class JsonFieldTypeResolver {
 	JsonFieldType resolveFieldType(String path, Object payload) {
 		JsonFieldPath fieldPath = JsonFieldPath.compile(path);
 		Object field = this.fieldProcessor.extract(fieldPath, payload);
-		if (field instanceof Collection && !fieldPath.isPrecise()) {
+
+		if (field instanceof Collection && !fieldPath.isArray()
+				&& !((Collection<?>) field).isEmpty()) {
 			JsonFieldType commonType = null;
 			for (Object item : (Collection<?>) field) {
 				JsonFieldType fieldType = determineFieldType(item);
@@ -44,6 +47,7 @@ class JsonFieldTypeResolver {
 			}
 			return commonType;
 		}
+
 		return determineFieldType(field);
 	}
 

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
@@ -96,6 +96,20 @@ public class JsonFieldPathTests {
 	}
 
 	@Test
+	public void fieldBeneathTopLevelWildcardIsNotPreciseAndNotAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("*.a");
+		assertFalse(path.isPrecise());
+		assertFalse(path.isArray());
+	}
+
+	@Test
+	public void fieldBeneathNestedWildcardIsNotPreciseAndNotAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("a.*.b");
+		assertFalse(path.isPrecise());
+		assertFalse(path.isArray());
+	}
+
+	@Test
 	public void compilationOfSingleElementPath() {
 		assertThat(JsonFieldPath.compile("a").getSegments(), contains("a"));
 	}
@@ -163,20 +177,6 @@ public class JsonFieldPathTests {
 	public void compilationOfPathWithAWildcardInBrackets() {
 		assertThat(JsonFieldPath.compile("a.b.['*'].c").getSegments(),
 				contains("a", "b", "*", "c"));
-	}
-
-	@Test
-	public void fieldBeneathTopLevelWildcardIsNotPreciseAndNotAnArray() {
-		JsonFieldPath path = JsonFieldPath.compile("*.a");
-		assertFalse(path.isPrecise());
-		assertFalse(path.isArray());
-	}
-
-	@Test
-	public void fieldBeneathNestedWildcardIsNotPreciseAndNotAnArray() {
-		JsonFieldPath path = JsonFieldPath.compile("a.*.b");
-		assertFalse(path.isPrecise());
-		assertFalse(path.isArray());
 	}
 
 }

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Andy Wilkinson
  * @author Jeremy Rickard
+ * @author Minhyeok Jeong
  */
 public class JsonFieldPathTests {
 
@@ -46,9 +47,9 @@ public class JsonFieldPathTests {
 	}
 
 	@Test
-	public void topLevelArrayIsPreciseAndAnArray() {
+	public void topLevelArrayIsNotPreciseAndAnArray() {
 		JsonFieldPath path = JsonFieldPath.compile("[]");
-		assertTrue(path.isPrecise());
+		assertFalse(path.isPrecise());
 		assertTrue(path.isArray());
 	}
 
@@ -60,16 +61,23 @@ public class JsonFieldPathTests {
 	}
 
 	@Test
-	public void arrayIsPreciseAndAnArray() {
+	public void arrayIsNotPreciseAndAnArray() {
 		JsonFieldPath path = JsonFieldPath.compile("a[]");
-		assertTrue(path.isPrecise());
+		assertFalse(path.isPrecise());
 		assertTrue(path.isArray());
 	}
 
 	@Test
-	public void nestedArrayIsPreciseAndAnArray() {
+	public void nestedArrayIsNotPreciseAndAnArray() {
 		JsonFieldPath path = JsonFieldPath.compile("a.b[]");
-		assertTrue(path.isPrecise());
+		assertFalse(path.isPrecise());
+		assertTrue(path.isArray());
+	}
+
+	@Test
+	public void nestedArrayStartedWithArrayIsNotPreciseAndAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("[].a[]");
+		assertFalse(path.isPrecise());
 		assertTrue(path.isArray());
 	}
 

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldProcessorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldProcessorTests.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertThat;
  * Tests for {@link JsonFieldProcessor}.
  *
  * @author Andy Wilkinson
+ * @author Minhyeok Jeong
  */
 public class JsonFieldProcessorTests {
 
@@ -169,6 +170,24 @@ public class JsonFieldProcessorTests {
 		payload.put("a", alpha);
 		assertThat(
 				this.fieldProcessor.extract(JsonFieldPath.compile("a[][].ids"), payload),
+				equalTo((Object) Arrays.asList(Arrays.asList(1, 2), Arrays.asList(3),
+						Arrays.asList(4))));
+	}
+
+	@Test
+	public void extractArraysFromItemsInNestedArrayStartedWithArray() {
+		List<Object> payload = new ArrayList<>();
+		Map<String, Object> alpha = new HashMap<>();
+		Map<String, Object> entry1 = createEntry("ids", Arrays.asList(1, 2));
+		Map<String, Object> entry2 = createEntry("ids", Arrays.asList(3));
+		Map<String, Object> entry3 = createEntry("ids", Arrays.asList(4));
+		List<List<Map<String, Object>>> bravo = Arrays
+				.asList(Arrays.asList(entry1, entry2), Arrays.asList(entry3));
+		alpha.put("a", bravo);
+		payload.add(alpha);
+		assertThat(
+				this.fieldProcessor.extract(JsonFieldPath.compile("[].a[][].ids"),
+						payload),
 				equalTo((Object) Arrays.asList(Arrays.asList(1, 2), Arrays.asList(3),
 						Arrays.asList(4))));
 	}

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldTypeResolverTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldTypeResolverTests.java
@@ -47,6 +47,31 @@ public class JsonFieldTypeResolverTests {
 	}
 
 	@Test
+	public void objectField() throws IOException {
+		assertFieldType(JsonFieldType.OBJECT, "{}");
+	}
+
+	@Test
+	public void booleanField() throws IOException {
+		assertFieldType(JsonFieldType.BOOLEAN, "true");
+	}
+
+	@Test
+	public void nullField() throws IOException {
+		assertFieldType(JsonFieldType.NULL, "null");
+	}
+
+	@Test
+	public void numberField() throws IOException {
+		assertFieldType(JsonFieldType.NUMBER, "1.2345");
+	}
+
+	@Test
+	public void stringField() throws IOException {
+		assertFieldType(JsonFieldType.STRING, "\"Foo\"");
+	}
+
+	@Test
 	public void topLevelArray() throws IOException {
 		assertThat(
 				this.fieldTypeResolver.resolveFieldType("[]",
@@ -65,34 +90,11 @@ public class JsonFieldTypeResolverTests {
 	@Test
 	public void nestedArrayStartedWithArray() throws IOException {
 		assertThat(
-				this.fieldTypeResolver.resolveFieldType("[].a[]",
-						new ObjectMapper().readValue("[{\"a\": [{\"b\":\"bravo\"}]}]", List.class)),
+				this.fieldTypeResolver
+						.resolveFieldType("[].a[]",
+								new ObjectMapper().readValue(
+										"[{\"a\": [{\"b\":\"bravo\"}]}]", List.class)),
 				equalTo(JsonFieldType.ARRAY));
-	}
-
-	@Test
-	public void booleanField() throws IOException {
-		assertFieldType(JsonFieldType.BOOLEAN, "true");
-	}
-
-	@Test
-	public void objectField() throws IOException {
-		assertFieldType(JsonFieldType.OBJECT, "{}");
-	}
-
-	@Test
-	public void nullField() throws IOException {
-		assertFieldType(JsonFieldType.NULL, "null");
-	}
-
-	@Test
-	public void numberField() throws IOException {
-		assertFieldType(JsonFieldType.NUMBER, "1.2345");
-	}
-
-	@Test
-	public void stringField() throws IOException {
-		assertFieldType(JsonFieldType.STRING, "\"Foo\"");
 	}
 
 	@Test

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldTypeResolverTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldTypeResolverTests.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertThat;
  * Tests for {@link JsonFieldTypeResolver}.
  *
  * @author Andy Wilkinson
- *
+ * @author Minhyeok Jeong
  */
 public class JsonFieldTypeResolverTests {
 
@@ -59,6 +59,14 @@ public class JsonFieldTypeResolverTests {
 		assertThat(
 				this.fieldTypeResolver.resolveFieldType("a[]",
 						createPayload("{\"a\": [{\"b\":\"bravo\"}]}")),
+				equalTo(JsonFieldType.ARRAY));
+	}
+
+	@Test
+	public void nestedArrayStartedWithArray() throws IOException {
+		assertThat(
+				this.fieldTypeResolver.resolveFieldType("[].a[]",
+						new ObjectMapper().readValue("[{\"a\": [{\"b\":\"bravo\"}]}]", List.class)),
 				equalTo(JsonFieldType.ARRAY));
 	}
 


### PR DESCRIPTION
This PR updates the logic to determine the type of nested array correctly.

For example,
a path "[]" was correctly determined as Array,
but a path "[].a[]" was incorrectly determined as Object.

This PR determines the path "[].a[]" as Array rather than Object.