### PR TITLE
Fix JSON field type resolution for nested array fields

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.restdocs.payload;
 
 import java.io.IOException;
-import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -28,6 +27,7 @@ import org.springframework.http.MediaType;
  * identified by a field path.
  *
  * @author Andy Wilkinson
+ * @author Minhyeok Jeong
  * @since 1.2.0
  * @see PayloadDocumentation#beneathPath(String)
  */
@@ -69,8 +69,8 @@ public class FieldPathPayloadSubsectionExtractor
 			JsonFieldPath compiledPath = JsonFieldPath.compile(this.fieldPath);
 			Object extracted = new JsonFieldProcessor().extract(compiledPath,
 					objectMapper.readValue(payload, Object.class));
-			if (extracted instanceof List && !compiledPath.isPrecise()) {
-				List<?> extractedList = (List<?>) extracted;
+			if (extracted instanceof JsonFieldList) {
+				JsonFieldList<?> extractedList = (JsonFieldList<?>) extracted;
 				if (extractedList.size() == 1) {
 					extracted = extractedList.get(0);
 				}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldList.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldList.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.payload;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * A list of JSON fields. This list contains extracted values by {@code JsonFieldPath}
+ * from the JSON payload.
+ *
+ * @param <E> the type of elements in this list
+ *
+ * @author Minhyeok Jeong
+ */
+final class JsonFieldList<E> extends ArrayList<E> {
+
+	/**
+	 * Constructs a list containing the elements of the specified collection, in the order
+	 * they are returned by the collection's iterator.
+	 *
+	 * @param c the collection whose elements are to be placed into this list
+	 * @throws NullPointerException if the specified collection is null
+	 * @see ArrayList#ArrayList(Collection)
+	 */
+	public JsonFieldList(Collection<? extends E> c) {
+		super(c);
+	}
+
+}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldList.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldList.java
@@ -37,7 +37,7 @@ final class JsonFieldList<E> extends ArrayList<E> {
 	 * @throws NullPointerException if the specified collection is null
 	 * @see ArrayList#ArrayList(Collection)
 	 */
-	public JsonFieldList(Collection<? extends E> c) {
+	JsonFieldList(Collection<? extends E> c) {
 		super(c);
 	}
 

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldPath.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.restdocs.payload;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -27,7 +26,7 @@ import java.util.regex.Pattern;
  *
  * @author Andy Wilkinson
  * @author Jeremy Rickard
- *
+ * @author Minhyeok Jeong
  */
 final class JsonFieldPath {
 
@@ -41,8 +40,13 @@ final class JsonFieldPath {
 
 	private final List<String> segments;
 
+	/**
+	 * Whether this path indicates a specific value which is neither an array nor an
+	 * object.
+	 */
 	private final boolean precise;
 
+	/** Whether this path indicates a value which is an array. */
 	private final boolean array;
 
 	private JsonFieldPath(String rawPath, List<String> segments, boolean precise,
@@ -81,11 +85,9 @@ final class JsonFieldPath {
 		return ARRAY_INDEX_PATTERN.matcher(segment).matches();
 	}
 
-	static boolean matchesSingleValue(List<String> segments) {
-		Iterator<String> iterator = segments.iterator();
-		while (iterator.hasNext()) {
-			String next = iterator.next();
-			if ((isArraySegment(next) || isWildcardSegment(next)) && iterator.hasNext()) {
+	private static boolean matchesSingleValue(List<String> segments) {
+		for (String segment : segments) {
+			if (isArraySegment(segment) || isWildcardSegment(segment)) {
 				return false;
 			}
 		}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldProcessor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldProcessor.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * extracted and removed.
  *
  * @author Andy Wilkinson
- *
+ * @author Minhyeok Jeong
  */
 final class JsonFieldProcessor {
 
@@ -37,6 +37,17 @@ final class JsonFieldProcessor {
 		return callback.fieldFound();
 	}
 
+	/**
+	 * Extracts the identified object from the specified JSON payload using the specified
+	 * path. If the path does not indicate an array and multiple values are matched, it
+	 * returns a list as {@code JsonFieldList}, so the result can be distinguished from a
+	 * pure {@code List} which is extracted because of the path indicates a real array
+	 * value.
+	 *
+	 * @param path the JSON field path
+	 * @param payload the JSON payload
+	 * @return the extracted object by the path
+	 */
 	Object extract(JsonFieldPath path, Object payload) {
 		final List<Object> matches = new ArrayList<>();
 		traverse(new ProcessingContext(payload, path), new MatchCallback() {
@@ -48,18 +59,22 @@ final class JsonFieldProcessor {
 
 			@Override
 			public void absent() {
-
 			}
 
 		});
+
 		if (matches.isEmpty()) {
 			throw new FieldDoesNotExistException(path);
 		}
-		if ((!path.isArray()) && path.isPrecise()) {
+
+		if (path.isPrecise()) {
 			return matches.get(0);
 		}
-		else {
+		else if (path.isArray()) {
 			return matches;
+		}
+		else {
+			return new JsonFieldList<>(matches);
 		}
 	}
 
@@ -73,7 +88,6 @@ final class JsonFieldProcessor {
 
 			@Override
 			public void absent() {
-
 			}
 
 		});
@@ -89,7 +103,6 @@ final class JsonFieldProcessor {
 
 			@Override
 			public void absent() {
-
 			}
 
 		});

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldTypeResolver.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonFieldTypeResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Map;
  * Resolves the type of a field in a JSON request or response payload.
  *
  * @author Andy Wilkinson
+ * @author Minhyeok Jeong
  */
 class JsonFieldTypeResolver {
 
@@ -31,9 +32,10 @@ class JsonFieldTypeResolver {
 	JsonFieldType resolveFieldType(String path, Object payload) {
 		JsonFieldPath fieldPath = JsonFieldPath.compile(path);
 		Object field = this.fieldProcessor.extract(fieldPath, payload);
-		if (field instanceof Collection && !fieldPath.isPrecise()) {
+
+		if (field instanceof JsonFieldList) {
 			JsonFieldType commonType = null;
-			for (Object item : (Collection<?>) field) {
+			for (Object item : (JsonFieldList<?>) field) {
 				JsonFieldType fieldType = determineFieldType(item);
 				if (commonType == null) {
 					commonType = fieldType;
@@ -44,6 +46,7 @@ class JsonFieldTypeResolver {
 			}
 			return commonType;
 		}
+
 		return determineFieldType(field);
 	}
 
@@ -65,4 +68,5 @@ class JsonFieldTypeResolver {
 		}
 		return JsonFieldType.NUMBER;
 	}
+
 }

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
@@ -54,6 +54,20 @@ public class JsonFieldPathTests {
 	}
 
 	@Test
+	public void fieldBeneathTopLevelArrayIsNotPreciseAndNotAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("[]a");
+		assertFalse(path.isPrecise());
+		assertFalse(path.isArray());
+	}
+
+	@Test
+	public void arrayIsNotPreciseAndAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("a[]");
+		assertFalse(path.isPrecise());
+		assertTrue(path.isArray());
+	}
+
+	@Test
 	public void nestedArrayIsNotPreciseAndAnArray() {
 		JsonFieldPath path = JsonFieldPath.compile("a.b[]");
 		assertFalse(path.isPrecise());
@@ -163,20 +177,6 @@ public class JsonFieldPathTests {
 	public void compilationOfPathWithAWildcardInBrackets() {
 		assertThat(JsonFieldPath.compile("a.b.['*'].c").getSegments(),
 				contains("a", "b", "*", "c"));
-	}
-
-	@Test
-	public void fieldBeneathTopLevelArrayIsNotPreciseAndNotAnArray() {
-		JsonFieldPath path = JsonFieldPath.compile("[]a");
-		assertFalse(path.isPrecise());
-		assertFalse(path.isArray());
-	}
-
-	@Test
-	public void arrayIsNotPreciseAndAnArray() {
-		JsonFieldPath path = JsonFieldPath.compile("a[]");
-		assertFalse(path.isPrecise());
-		assertTrue(path.isArray());
 	}
 
 }

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Andy Wilkinson
  * @author Jeremy Rickard
+ * @author Minhyeok Jeong
  */
 public class JsonFieldPathTests {
 
@@ -46,30 +47,23 @@ public class JsonFieldPathTests {
 	}
 
 	@Test
-	public void topLevelArrayIsPreciseAndAnArray() {
+	public void topLevelArrayIsNotPreciseAndAnArray() {
 		JsonFieldPath path = JsonFieldPath.compile("[]");
-		assertTrue(path.isPrecise());
-		assertTrue(path.isArray());
-	}
-
-	@Test
-	public void fieldBeneathTopLevelArrayIsNotPreciseAndNotAnArray() {
-		JsonFieldPath path = JsonFieldPath.compile("[]a");
 		assertFalse(path.isPrecise());
-		assertFalse(path.isArray());
-	}
-
-	@Test
-	public void arrayIsPreciseAndAnArray() {
-		JsonFieldPath path = JsonFieldPath.compile("a[]");
-		assertTrue(path.isPrecise());
 		assertTrue(path.isArray());
 	}
 
 	@Test
-	public void nestedArrayIsPreciseAndAnArray() {
+	public void nestedArrayIsNotPreciseAndAnArray() {
 		JsonFieldPath path = JsonFieldPath.compile("a.b[]");
-		assertTrue(path.isPrecise());
+		assertFalse(path.isPrecise());
+		assertTrue(path.isArray());
+	}
+
+	@Test
+	public void nestedArrayStartedWithArrayIsNotPreciseAndAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("[].a[]");
+		assertFalse(path.isPrecise());
 		assertTrue(path.isArray());
 	}
 
@@ -83,6 +77,20 @@ public class JsonFieldPathTests {
 	@Test
 	public void fieldBeneathAnArrayIsNotPreciseAndIsNotAnArray() {
 		JsonFieldPath path = JsonFieldPath.compile("a[].b");
+		assertFalse(path.isPrecise());
+		assertFalse(path.isArray());
+	}
+
+	@Test
+	public void fieldBeneathTopLevelWildcardIsNotPreciseAndNotAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("*.a");
+		assertFalse(path.isPrecise());
+		assertFalse(path.isArray());
+	}
+
+	@Test
+	public void fieldBeneathNestedWildcardIsNotPreciseAndNotAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("a.*.b");
 		assertFalse(path.isPrecise());
 		assertFalse(path.isArray());
 	}
@@ -158,17 +166,17 @@ public class JsonFieldPathTests {
 	}
 
 	@Test
-	public void fieldBeneathTopLevelWildcardIsNotPreciseAndNotAnArray() {
-		JsonFieldPath path = JsonFieldPath.compile("*.a");
+	public void fieldBeneathTopLevelArrayIsNotPreciseAndNotAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("[]a");
 		assertFalse(path.isPrecise());
 		assertFalse(path.isArray());
 	}
 
 	@Test
-	public void fieldBeneathNestedWildcardIsNotPreciseAndNotAnArray() {
-		JsonFieldPath path = JsonFieldPath.compile("a.*.b");
+	public void arrayIsNotPreciseAndAnArray() {
+		JsonFieldPath path = JsonFieldPath.compile("a[]");
 		assertFalse(path.isPrecise());
-		assertFalse(path.isArray());
+		assertTrue(path.isArray());
 	}
 
 }

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldProcessorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldProcessorTests.java
@@ -39,6 +39,7 @@ import static org.junit.Assert.assertThat;
  * Tests for {@link JsonFieldProcessor}.
  *
  * @author Andy Wilkinson
+ * @author Minhyeok Jeong
  */
 public class JsonFieldProcessorTests {
 
@@ -71,6 +72,36 @@ public class JsonFieldProcessorTests {
 		payload.add(bravo);
 		assertThat(this.fieldProcessor.extract(JsonFieldPath.compile("[]"), payload),
 				equalTo((Object) payload));
+	}
+
+	@Test
+	public void extractNestedArrayStartedWithArray() {
+		List<Object> payload = new ArrayList<>();
+		Map<String, Object> alpha = new HashMap<>();
+		List<Map<String, Object>> bravo = new ArrayList<>();
+		Map<String, Object> charlie = new HashMap<>();
+		charlie.put("c", "charlie");
+		bravo.add(charlie);
+		bravo.add(charlie);
+		alpha.put("b", bravo);
+		payload.add(alpha);
+		assertThat(this.fieldProcessor.extract(JsonFieldPath.compile("[]b"), payload),
+				equalTo((Object) Arrays.asList(bravo)));
+	}
+
+	@Test
+	public void extractNestedArraySurroundedWithArray() {
+		List<Object> payload = new ArrayList<>();
+		Map<String, Object> alpha = new HashMap<>();
+		List<Map<String, Object>> bravo = new ArrayList<>();
+		Map<String, Object> charlie = new HashMap<>();
+		charlie.put("c", "charlie");
+		bravo.add(charlie);
+		bravo.add(charlie);
+		alpha.put("b", bravo);
+		payload.add(alpha);
+		assertThat(this.fieldProcessor.extract(JsonFieldPath.compile("[]b[]"), payload),
+				equalTo((Object) bravo));
 	}
 
 	@Test
@@ -169,6 +200,24 @@ public class JsonFieldProcessorTests {
 		payload.put("a", alpha);
 		assertThat(
 				this.fieldProcessor.extract(JsonFieldPath.compile("a[][].ids"), payload),
+				equalTo((Object) Arrays.asList(Arrays.asList(1, 2), Arrays.asList(3),
+						Arrays.asList(4))));
+	}
+
+	@Test
+	public void extractArraysFromItemsInNestedArrayStartedWithArray() {
+		List<Object> payload = new ArrayList<>();
+		Map<String, Object> alpha = new HashMap<>();
+		Map<String, Object> entry1 = createEntry("ids", Arrays.asList(1, 2));
+		Map<String, Object> entry2 = createEntry("ids", Arrays.asList(3));
+		Map<String, Object> entry3 = createEntry("ids", Arrays.asList(4));
+		List<List<Map<String, Object>>> bravo = Arrays
+				.asList(Arrays.asList(entry1, entry2), Arrays.asList(entry3));
+		alpha.put("a", bravo);
+		payload.add(alpha);
+		assertThat(
+				this.fieldProcessor.extract(JsonFieldPath.compile("[].a[][].ids"),
+						payload),
 				equalTo((Object) Arrays.asList(Arrays.asList(1, 2), Arrays.asList(3),
 						Arrays.asList(4))));
 	}

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldTypeResolverTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldTypeResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2015 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertThat;
  * Tests for {@link JsonFieldTypeResolver}.
  *
  * @author Andy Wilkinson
- *
+ * @author Minhyeok Jeong
  */
 public class JsonFieldTypeResolverTests {
 
@@ -59,6 +59,16 @@ public class JsonFieldTypeResolverTests {
 		assertThat(
 				this.fieldTypeResolver.resolveFieldType("a[]",
 						createPayload("{\"a\": [{\"b\":\"bravo\"}]}")),
+				equalTo(JsonFieldType.ARRAY));
+	}
+
+	@Test
+	public void nestedArrayStartedWithArray() throws IOException {
+		assertThat(
+				this.fieldTypeResolver
+						.resolveFieldType("[].a[]",
+								new ObjectMapper().readValue(
+										"[{\"a\": [{\"b\":\"bravo\"}]}]", List.class)),
 				equalTo(JsonFieldType.ARRAY));
 	}
 

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldTypeResolverTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldTypeResolverTests.java
@@ -47,6 +47,31 @@ public class JsonFieldTypeResolverTests {
 	}
 
 	@Test
+	public void objectField() throws IOException {
+		assertFieldType(JsonFieldType.OBJECT, "{}");
+	}
+
+	@Test
+	public void booleanField() throws IOException {
+		assertFieldType(JsonFieldType.BOOLEAN, "true");
+	}
+
+	@Test
+	public void nullField() throws IOException {
+		assertFieldType(JsonFieldType.NULL, "null");
+	}
+
+	@Test
+	public void numberField() throws IOException {
+		assertFieldType(JsonFieldType.NUMBER, "1.2345");
+	}
+
+	@Test
+	public void stringField() throws IOException {
+		assertFieldType(JsonFieldType.STRING, "\"Foo\"");
+	}
+
+	@Test
 	public void topLevelArray() throws IOException {
 		assertThat(
 				this.fieldTypeResolver.resolveFieldType("[]",
@@ -70,31 +95,6 @@ public class JsonFieldTypeResolverTests {
 								new ObjectMapper().readValue(
 										"[{\"a\": [{\"b\":\"bravo\"}]}]", List.class)),
 				equalTo(JsonFieldType.ARRAY));
-	}
-
-	@Test
-	public void booleanField() throws IOException {
-		assertFieldType(JsonFieldType.BOOLEAN, "true");
-	}
-
-	@Test
-	public void objectField() throws IOException {
-		assertFieldType(JsonFieldType.OBJECT, "{}");
-	}
-
-	@Test
-	public void nullField() throws IOException {
-		assertFieldType(JsonFieldType.NULL, "null");
-	}
-
-	@Test
-	public void numberField() throws IOException {
-		assertFieldType(JsonFieldType.NUMBER, "1.2345");
-	}
-
-	@Test
-	public void stringField() throws IOException {
-		assertFieldType(JsonFieldType.STRING, "\"Foo\"");
 	}
 
 	@Test

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
@@ -43,6 +43,7 @@ import static org.springframework.restdocs.snippet.Attributes.key;
  * Tests for {@link ResponseFieldsSnippet}.
  *
  * @author Andy Wilkinson
+ * @author Minhyeok Jeong
  */
 public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 
@@ -58,17 +59,28 @@ public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 						.row("`assets`", "`Array`", "three")
 						.row("`assets[]`", "`Array`", "four")
 						.row("`assets[].id`", "`Number`", "five")
-						.row("`assets[].name`", "`String`", "six"));
+						.row("`assets[].name`", "`String`", "six")
+						.row("`properties`", "`Object`", "seven")
+						.row("`properties.*`", "`Array`", "eight")
+						.row("`properties.*.value`", "`Number`", "nine")
+						.row("`properties.*.desc`", "`String`", "ten"));
 		new ResponseFieldsSnippet(Arrays.asList(fieldWithPath("id").description("one"),
 				fieldWithPath("date").description("two"),
 				fieldWithPath("assets").description("three"),
 				fieldWithPath("assets[]").description("four"),
 				fieldWithPath("assets[].id").description("five"),
-				fieldWithPath("assets[].name").description("six")))
+				fieldWithPath("assets[].name").description("six"),
+				fieldWithPath("properties").description("seven"),
+				fieldWithPath("properties.*").description("eight"),
+				fieldWithPath("properties.*.value").description("nine"),
+				fieldWithPath("properties.*.desc").description("ten")))
 						.document(this.operationBuilder.response()
-								.content(
-										"{\"id\": 67,\"date\": \"2015-01-20\",\"assets\":"
-												+ " [{\"id\":356,\"name\": \"sample\"}]}")
+								.content("{\"id\": 67,\"date\": \"2015-01-20\","
+										+ "\"assets\": [{\"id\":356,\"name\": \"sample\"}],"
+										+ "\"properties\": {"
+										+ " \"foo\": {\"value\": 10, \"desc\": \"Some foo\"},"
+										+ " \"bar\": {\"value\": 20, \"desc\": \"Some bar\"}"
+										+ "}}")
 								.build());
 	}
 
@@ -101,13 +113,21 @@ public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 				.withContents(tableWithHeader("Path", "Type", "Description")
 						.row("`[]a.b`", "`Number`", "one")
 						.row("`[]a.c`", "`String`", "two")
-						.row("`[]a`", "`Object`", "three"));
+						.row("`[]a`", "`Object`", "three")
+						.row("`[]a.d`", "`Array`", "four")
+						.row("`[]a.d[]`", "`Array`", "five")
+						.row("`[]a.d[].e`", "`Number`", "six"));
 		new ResponseFieldsSnippet(Arrays.asList(fieldWithPath("[]a.b").description("one"),
 				fieldWithPath("[]a.c").description("two"),
-				fieldWithPath("[]a").description("three")))
+				fieldWithPath("[]a").description("three"),
+				fieldWithPath("[]a.d").description("four"),
+				fieldWithPath("[]a.d[]").description("five"),
+				fieldWithPath("[]a.d[].e").description("six")))
 						.document(this.operationBuilder.response()
-								.content("[{\"a\": {\"b\": 5, \"c\":\"charlie\"}},"
-										+ "{\"a\": {\"b\": 4, \"c\":\"chalk\"}}]")
+								.content("[{\"a\": {\"b\": 5, \"c\":\"charlie\","
+										+ " \"d\": [{\"e\": 10}, {\"e\": 20}]}},"
+										+ "{\"a\": {\"b\": 4, \"c\":\"chalk\","
+										+ " \"d\": [{\"e\": 30}, {\"e\": 40}]}}]")
 								.build());
 	}
 


### PR DESCRIPTION
This PR updates the logic to determine the type of nested array correctly.

For example,
a path "[]" was correctly determined as Array,
but a path "[].a[]" was incorrectly determined as Object.

This PR determines the path "[].a[]" as Array rather than Object.