### PR TITLE
Add support for configuring and using default Request and Response preprocessors

### DIFF
--- a/docs/src/docs/asciidoc/configuration.adoc
+++ b/docs/src/docs/asciidoc/configuration.adoc
@@ -114,3 +114,23 @@ include::{examples-dir}/com/example/mockmvc/CustomDefaultSnippets.java[tags=cust
 ----
 include::{examples-dir}/com/example/restassured/CustomDefaultSnippets.java[tags=custom-default-snippets]
 ----
+
+[[configuration-default-preprocessors]]
+=== Operation preprocessors
+
+You can configure default Request / Response preprocessors during setup using the
+`RestDocumentationConfigurer` API. For example, to remove the `Foo` headers from all requests
+and pretty print all responses:
+
+[source,java,indent=0,role="primary"]
+.MockMvc
+----
+include::{examples-dir}/com/example/mockmvc/CustomDefaultOperationPreprocessors.java[tags=custom-default-preprocessors]
+----
+
+[source,java,indent=0,role="secondary"]
+.REST Assured
+----
+include::{examples-dir}/com/example/restassured/CustomDefaultOperationPreprocessors.java[tags=custom-default-preprocessors]
+----
+

--- a/docs/src/docs/asciidoc/customizing-requests-and-responses.adoc
+++ b/docs/src/docs/asciidoc/customizing-requests-and-responses.adoc
@@ -27,29 +27,20 @@ include::{examples-dir}/com/example/restassured/PerTestPreprocessing.java[tags=p
 <2> Apply a response preprocessor that will pretty print its content.
 
 Alternatively, you may want to apply the same preprocessors to every test. You can do
-so by configuring the preprocessors in your `@Before` method and using the
-<<documentating-your-api-parameterized-output-directories, support for parameterized
-output directories>>:
+so by configuring the preprocessors using the `RestDocumentationConfigurer` API.
+For example to remove the `Foo` header from all requests and pretty print all responses:
 
 [source,java,indent=0,role="primary"]
 .MockMvc
 ----
 include::{examples-dir}/com/example/mockmvc/EveryTestPreprocessing.java[tags=setup]
 ----
-<1> Create a `RestDocumentationResultHandler`, configured to preprocess the request
-	and response.
-<2> Create a `MockMvc` instance, configured to always call the documentation result
-	handler.
 
 [source,java,indent=0,role="secondary"]
 .REST Assured
 ----
 include::{examples-dir}/com/example/restassured/EveryTestPreprocessing.java[tags=setup]
 ----
-<1> Create a `RestDocumentationFilter`, configured to preprocess the request
-	and response.
-<2> Create a `RequestSpecification` instance, configured to always call the documentation
-	filter.
 
 Then, in each test, any configuration specific to that test can be performed. For example:
 
@@ -58,17 +49,12 @@ Then, in each test, any configuration specific to that test can be performed. Fo
 ----
 include::{examples-dir}/com/example/mockmvc/EveryTestPreprocessing.java[tags=use]
 ----
-<1> The request and response will be preprocessed due to the use of `alwaysDo` above.
-<2> Document the links specific to the resource that is being tested
 
 [source,java,indent=0,role="secondary"]
 .REST Assured
 ----
 include::{examples-dir}/com/example/restassured/EveryTestPreprocessing.java[tags=use]
 ----
-<1> The request and response will be preprocessed due to the configuration of the
-`RequestSpecification` in the `setUp` method.
-<2> Document the links specific to the resource that is being tested
 
 Various built in preprocessors, including those illustrated above, are available via the
 static methods on `Preprocessors`. See <<Preprocessors, below>> for further details.

--- a/docs/src/test/java/com/example/mockmvc/CustomDefaultOperationPreprocessors.java
+++ b/docs/src/test/java/com/example/mockmvc/CustomDefaultOperationPreprocessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,49 +18,33 @@ package com.example.mockmvc;
 
 import org.junit.Before;
 import org.junit.Rule;
+
 import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class EveryTestPreprocessing {
+public class CustomDefaultOperationPreprocessors {
 
 	@Rule
 	public final JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation();
 
 	private WebApplicationContext context;
 
-	// tag::setup[]
 	private MockMvc mockMvc;
 
 	@Before
 	public void setup() {
+		// tag::custom-default-preprocessors[]
 		this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
 				.apply(documentationConfiguration(this.restDocumentation).operationPreprocessors()
 						.withDefaultRequestPreprocessors(removeHeaders("Foo"))
 						.withDefaultResponsePreprocessors(prettyPrint()))
 				.build();
+		// end::custom-default-preprocessors[]
 	}
-
-	// end::setup[]
-
-	public void use() throws Exception {
-		// tag::use[]
-		this.mockMvc.perform(get("/")) // <1>
-				.andExpect(status().isOk())
-				.andDo(document("{method-name}",
-						links(linkWithRel("self").description("Canonical self link"))
-				));
-		// end::use[]
-	}
-
 }

--- a/docs/src/test/java/com/example/restassured/CustomDefaultOperationPreprocessors.java
+++ b/docs/src/test/java/com/example/restassured/CustomDefaultOperationPreprocessors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2017 the original author or authors.
+ * Copyright 2014-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,49 +16,34 @@
 
 package com.example.restassured;
 
-import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
+
 import org.junit.Before;
 import org.junit.Rule;
 
 import org.springframework.restdocs.JUnitRestDocumentation;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.removeHeaders;
-import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
-public class EveryTestPreprocessing {
+public class CustomDefaultOperationPreprocessors {
 
 	@Rule
 	public final JUnitRestDocumentation restDocumentation = new JUnitRestDocumentation();
 
-	// tag::setup[]
+	@SuppressWarnings("unused")
 	private RequestSpecification spec;
 
 	@Before
 	public void setup() {
+		// tag::custom-default-preprocessors[]
 		this.spec = new RequestSpecBuilder()
 				.addFilter(documentationConfiguration(this.restDocumentation).operationPreprocessors()
 						.withDefaultRequestPreprocessors(removeHeaders("Foo"))
 						.withDefaultResponsePreprocessors(prettyPrint()))
 				.build();
+		// end::custom-default-preprocessors[]
 	}
-
-	// end::setup[]
-
-	public void use() throws Exception {
-		// tag::use[]
-		RestAssured.given(this.spec)
-				.filter(document("{method-name]",
-					links(linkWithRel("self").description("Canonical self link"))))
-			.when().get("/")
-			.then().assertThat().statusCode(is(200));
-		// end::use[]
-	}
-
 }

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/config/OperationPreprocessorsConfigurer.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/config/OperationPreprocessorsConfigurer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.config;
+
+import java.util.Map;
+
+import org.springframework.restdocs.RestDocumentationContext;
+import org.springframework.restdocs.generate.RestDocumentationGenerator;
+import org.springframework.restdocs.operation.preprocess.OperationPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+
+/**
+ * A configurer that can be used to configure the default operation preprocessors that need to be used.
+ *
+ * @param <PARENT> The type of the configurer's parent
+ * @param <TYPE> The concrete type of the configurer to be returned from chained methods
+ * @author Filip Hrisafov
+ * @since 2.0.0
+ */
+public abstract class OperationPreprocessorsConfigurer<PARENT, TYPE>
+		extends AbstractNestedConfigurer<PARENT> {
+
+	private OperationRequestPreprocessor defaultOperationRequestPreprocessor;
+	private OperationResponsePreprocessor defaultOperationResponsePreprocessor;
+
+	/**
+	 * Creates a new {@code OperationPreprocessorConfigurer} with the given {@code parent}.
+	 *
+	 * @param parent the parent
+	 */
+	protected OperationPreprocessorsConfigurer(PARENT parent) {
+		super(parent);
+	}
+
+	@Override
+	public void apply(Map<String, Object> configuration, RestDocumentationContext context) {
+		configuration.put(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_REQUEST_PREPROCESSOR,
+				this.defaultOperationRequestPreprocessor);
+		configuration.put(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_RESPONSE_PREPROCESSOR,
+				this.defaultOperationResponsePreprocessor);
+	}
+
+	/**
+	 * Configures the default documentation operation request preprocessors.
+	 *
+	 * @param preprocessors the preprocessors
+	 * @return {@code this}
+	 */
+	@SuppressWarnings("unchecked")
+	public TYPE withDefaultRequestPreprocessors(OperationPreprocessor... preprocessors) {
+		this.defaultOperationRequestPreprocessor = Preprocessors.preprocessRequest(preprocessors);
+		return (TYPE) this;
+	}
+
+	/**
+	 * Configures the default documentation operation response preprocessors.
+	 *
+	 * @param preprocessors the preprocessors
+	 * @return {@code this}
+	 */
+	@SuppressWarnings("unchecked")
+	public TYPE withDefaultResponsePreprocessors(OperationPreprocessor... preprocessors) {
+		this.defaultOperationResponsePreprocessor = Preprocessors.preprocessResponse(preprocessors);
+		return (TYPE) this;
+	}
+}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/config/RestDocumentationConfigurer.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/config/RestDocumentationConfigurer.java
@@ -36,12 +36,14 @@ import org.springframework.restdocs.templates.mustache.MustacheTemplateEngine;
  * Abstract base class for the configuration of Spring REST Docs.
  *
  * @param <S> The concrete type of the {@link SnippetConfigurer}.
+ * @param <P> The concrete type of the {@link OperationPreprocessorsConfigurer}
  * @param <T> The concrete type of this configurer, to be returned from methods that
  * support chaining
  * @author Andy Wilkinson
+ * @author Filip Hrisafov
  * @since 1.1.0
  */
-public abstract class RestDocumentationConfigurer<S extends AbstractConfigurer, T> {
+public abstract class RestDocumentationConfigurer<S extends AbstractConfigurer, P extends AbstractConfigurer, T> {
 
 	private final WriterResolverConfigurer writerResolverConfigurer = new WriterResolverConfigurer();
 
@@ -54,6 +56,14 @@ public abstract class RestDocumentationConfigurer<S extends AbstractConfigurer, 
 	 * @return the snippet configurer
 	 */
 	public abstract S snippets();
+
+	/**
+	 * Returns an {@link OperationPreprocessorsConfigurer} that can be used to configure the operation request and
+	 * response preprocessors that will be used during the documentation.
+	 *
+	 * @return the operation preprocessors configurer
+	 */
+	public abstract P operationPreprocessors();
 
 	/**
 	 * Configures the {@link TemplateEngine} that will be used for snippet rendering.
@@ -90,6 +100,7 @@ public abstract class RestDocumentationConfigurer<S extends AbstractConfigurer, 
 	protected final void apply(Map<String, Object> configuration,
 			RestDocumentationContext context) {
 		List<AbstractConfigurer> configurers = Arrays.asList(snippets(),
+				operationPreprocessors(),
 				this.templateEngineConfigurer, this.writerResolverConfigurer);
 		for (AbstractConfigurer configurer : configurers) {
 			configurer.apply(configuration, context);

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/RestDocumentationGeneratorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/RestDocumentationGeneratorTests.java
@@ -35,8 +35,10 @@ import org.springframework.restdocs.operation.OperationResponse;
 import org.springframework.restdocs.operation.OperationResponseFactory;
 import org.springframework.restdocs.operation.RequestConverter;
 import org.springframework.restdocs.operation.ResponseConverter;
+import org.springframework.restdocs.operation.preprocess.OperationPreprocessor;
 import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
 import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
 import org.springframework.restdocs.snippet.Snippet;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -51,6 +53,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  * Tests for {@link RestDocumentationGenerator}.
  *
  * @author Andy Wilkinson
+ * @author Filip Hrisafov
  */
 public class RestDocumentationGeneratorTests {
 
@@ -74,6 +77,9 @@ public class RestDocumentationGeneratorTests {
 			.create(null, null, null);
 
 	private final Snippet snippet = mock(Snippet.class);
+
+	private final OperationPreprocessor requestPreprocessor = mock(OperationPreprocessor.class);
+	private final OperationPreprocessor responsePreprocessor = mock(OperationPreprocessor.class);
 
 	@Test
 	public void basicHandling() throws IOException {
@@ -105,6 +111,84 @@ public class RestDocumentationGeneratorTests {
 		verifySnippetInvocation(this.snippet, configuration);
 		verifySnippetInvocation(defaultSnippet1, configuration);
 		verifySnippetInvocation(defaultSnippet2, configuration);
+	}
+
+	@Test
+	public void defaultOperationRequestPreprocessorsAreCalled() throws IOException {
+		given(this.requestConverter.convert(this.request))
+				.willReturn(this.operationRequest);
+		given(this.responseConverter.convert(this.response))
+				.willReturn(this.operationResponse);
+		HashMap<String, Object> configuration = new HashMap<>();
+		OperationPreprocessor defaultPreprocessor1 = mock(OperationPreprocessor.class);
+		OperationPreprocessor defaultPreprocessor2 = mock(OperationPreprocessor.class);
+		configuration.put(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_REQUEST_PREPROCESSOR,
+				Preprocessors.preprocessRequest(defaultPreprocessor1, defaultPreprocessor2));
+		OperationRequest first = createRequest();
+		OperationRequest second = createRequest();
+		OperationRequest third = createRequest();
+		given(this.requestPreprocessor.preprocess(this.operationRequest)).willReturn(first);
+		given(defaultPreprocessor1.preprocess(first)).willReturn(second);
+		given(defaultPreprocessor2.preprocess(second)).willReturn(third);
+		new RestDocumentationGenerator<>("id", this.requestConverter,
+				this.responseConverter, Preprocessors.preprocessRequest(this.requestPreprocessor), this.snippet)
+				.handle(this.request, this.response, configuration);
+
+		verifySnippetInvocation(this.snippet, third, this.operationResponse, configuration, 1);
+	}
+
+	@Test
+	public void defaultOperationResponsePreprocessorsAreCalled() throws IOException {
+		given(this.requestConverter.convert(this.request))
+				.willReturn(this.operationRequest);
+		given(this.responseConverter.convert(this.response))
+				.willReturn(this.operationResponse);
+		HashMap<String, Object> configuration = new HashMap<>();
+		OperationPreprocessor defaultPreprocessor1 = mock(OperationPreprocessor.class);
+		OperationPreprocessor defaultPreprocessor2 = mock(OperationPreprocessor.class);
+		configuration.put(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_RESPONSE_PREPROCESSOR,
+				Preprocessors.preprocessResponse(defaultPreprocessor1, defaultPreprocessor2));
+		OperationResponse first = createResponse();
+		OperationResponse second = createResponse();
+		OperationResponse third = new OperationResponseFactory().createFrom(this.operationResponse, new HttpHeaders());
+		given(this.responsePreprocessor.preprocess(this.operationResponse)).willReturn(first);
+		given(defaultPreprocessor1.preprocess(first)).willReturn(second);
+		given(defaultPreprocessor2.preprocess(second)).willReturn(third);
+		new RestDocumentationGenerator<>("id", this.requestConverter,
+				this.responseConverter, Preprocessors.preprocessResponse(this.responsePreprocessor), this.snippet)
+				.handle(this.request, this.response, configuration);
+
+		verifySnippetInvocation(this.snippet, this.operationRequest, third, configuration, 1);
+	}
+
+	@Test
+	public void defaultOperationPreprocessorsAreCalled() throws IOException {
+		given(this.requestConverter.convert(this.request))
+				.willReturn(this.operationRequest);
+		given(this.responseConverter.convert(this.response))
+				.willReturn(this.operationResponse);
+		HashMap<String, Object> configuration = new HashMap<>();
+		OperationPreprocessor requestPreprocessor1 = mock(OperationPreprocessor.class);
+		configuration.put(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_REQUEST_PREPROCESSOR,
+				Preprocessors.preprocessRequest(requestPreprocessor1));
+		OperationRequest firstRequest = createRequest();
+		OperationRequest secondRequest = createRequest();
+		given(this.requestPreprocessor.preprocess(this.operationRequest)).willReturn(firstRequest);
+		given(requestPreprocessor1.preprocess(firstRequest)).willReturn(secondRequest);
+
+		OperationPreprocessor responsePreprocessor1 = mock(OperationPreprocessor.class);
+		configuration.put(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_RESPONSE_PREPROCESSOR,
+				Preprocessors.preprocessResponse(responsePreprocessor1));
+		OperationResponse firstResponse = createResponse();
+		OperationResponse secondResponse = createResponse();
+		given(this.responsePreprocessor.preprocess(this.operationResponse)).willReturn(firstResponse);
+		given(responsePreprocessor1.preprocess(firstResponse)).willReturn(secondResponse);
+		new RestDocumentationGenerator<>("id", this.requestConverter,
+				this.responseConverter, Preprocessors.preprocessRequest(this.requestPreprocessor),
+				Preprocessors.preprocessResponse(this.responsePreprocessor), this.snippet)
+				.handle(this.request, this.response, configuration);
+
+		verifySnippetInvocation(this.snippet, secondRequest, secondResponse, configuration, 1);
 	}
 
 	@Test
@@ -141,12 +225,27 @@ public class RestDocumentationGeneratorTests {
 
 	private void verifySnippetInvocation(Snippet snippet, Map<String, Object> attributes,
 			int times) throws IOException {
+		verifySnippetInvocation(snippet, this.operationRequest, this.operationResponse, attributes, times);
+	}
+
+	private void verifySnippetInvocation(Snippet snippet, OperationRequest operationRequest,
+			OperationResponse operationResponse,
+			Map<String, Object> attributes, int times) throws IOException {
 		ArgumentCaptor<Operation> operation = ArgumentCaptor.forClass(Operation.class);
 		verify(snippet, Mockito.times(times)).document(operation.capture());
-		assertThat(this.operationRequest, is(equalTo(operation.getValue().getRequest())));
-		assertThat(this.operationResponse,
-				is(equalTo(operation.getValue().getResponse())));
+		assertThat(operationRequest, is(equalTo(operation.getValue().getRequest())));
+		assertThat(operationResponse, is(equalTo(operation.getValue().getResponse())));
 		assertThat(attributes, is(equalTo(operation.getValue().getAttributes())));
+	}
+
+	private static OperationRequest createRequest() {
+		return new OperationRequestFactory()
+				.create(URI.create("http://localhost:8080"), null, null, new HttpHeaders(), null, null);
+	}
+
+	private static OperationResponse createResponse() {
+		return new OperationResponseFactory()
+				.create(null, null, null);
 	}
 
 }

--- a/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/MockMvcOperationPreprocessorsConfigurer.java
+++ b/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/MockMvcOperationPreprocessorsConfigurer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.mockmvc;
+
+import org.springframework.restdocs.config.OperationPreprocessorsConfigurer;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcConfigurer;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * A configurer that can be used to configure the operation preprocessors.
+ *
+ * @author Filip Hrisafov
+ * @since 2.0.0
+ */
+public final class MockMvcOperationPreprocessorsConfigurer extends
+		OperationPreprocessorsConfigurer<MockMvcRestDocumentationConfigurer, MockMvcOperationPreprocessorsConfigurer>
+		implements MockMvcConfigurer {
+
+	MockMvcOperationPreprocessorsConfigurer(MockMvcRestDocumentationConfigurer parent) {
+		super(parent);
+	}
+
+	@Override
+	public void afterConfigurerAdded(ConfigurableMockMvcBuilder<?> builder) {
+		and().afterConfigurerAdded(builder);
+	}
+
+	@Override
+	public RequestPostProcessor beforeMockMvcCreated(
+			ConfigurableMockMvcBuilder<?> builder, WebApplicationContext context) {
+		return and().beforeMockMvcCreated(builder, context);
+	}
+}

--- a/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/MockMvcRestDocumentationConfigurer.java
+++ b/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/MockMvcRestDocumentationConfigurer.java
@@ -33,16 +33,21 @@ import org.springframework.web.context.WebApplicationContext;
  * A MockMvc-specific {@link RestDocumentationConfigurer}.
  *
  * @author Andy Wilkinson
+ * @author Filip Hrisafov
  * @since 1.1.0
  */
 public final class MockMvcRestDocumentationConfigurer extends
-		RestDocumentationConfigurer<MockMvcSnippetConfigurer, MockMvcRestDocumentationConfigurer>
+		RestDocumentationConfigurer<MockMvcSnippetConfigurer, MockMvcOperationPreprocessorsConfigurer,
+				MockMvcRestDocumentationConfigurer>
 		implements MockMvcConfigurer {
 
 	private final MockMvcSnippetConfigurer snippetConfigurer = new MockMvcSnippetConfigurer(
 			this);
 
 	private final UriConfigurer uriConfigurer = new UriConfigurer(this);
+
+	private final MockMvcOperationPreprocessorsConfigurer operationPreprocessorsConfigurer =
+			new MockMvcOperationPreprocessorsConfigurer(this);
 
 	private final RestDocumentationContextProvider contextManager;
 
@@ -74,6 +79,11 @@ public final class MockMvcRestDocumentationConfigurer extends
 	@Override
 	public MockMvcSnippetConfigurer snippets() {
 		return this.snippetConfigurer;
+	}
+
+	@Override
+	public MockMvcOperationPreprocessorsConfigurer operationPreprocessors() {
+		return this.operationPreprocessorsConfigurer;
 	}
 
 	private final class ConfigurerApplyingRequestPostProcessor

--- a/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/RestDocumentationResultHandler.java
+++ b/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/RestDocumentationResultHandler.java
@@ -82,6 +82,9 @@ public class RestDocumentationResultHandler implements ResultHandler {
 								.getAttribute(ATTRIBUTE_NAME_CONFIGURATION));
 				configuration.remove(
 						RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_SNIPPETS);
+				// TODO Do we need to remove the preprocessors here as well?
+				// I think that there is no test that evaluates this here. And the Javadoc does not reflect the
+				// behaviour
 				getDelegate().handle(result.getRequest(), result.getResponse(),
 						configuration);
 			}

--- a/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured3/RestAssuredOperationPreprocessorsConfigurer.java
+++ b/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured3/RestAssuredOperationPreprocessorsConfigurer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.restassured3;
+
+import io.restassured.filter.Filter;
+import io.restassured.filter.FilterContext;
+import io.restassured.response.Response;
+import io.restassured.specification.FilterableRequestSpecification;
+import io.restassured.specification.FilterableResponseSpecification;
+
+import org.springframework.restdocs.config.OperationPreprocessorsConfigurer;
+
+/**
+ * A configurer that can be used to configure the operation preprocessors when
+ * using REST Assured 3.
+ *
+ * @author Filip Hrisafov
+ * @since 2.0.0
+ */
+public final class RestAssuredOperationPreprocessorsConfigurer extends
+		OperationPreprocessorsConfigurer<RestAssuredRestDocumentationConfigurer,
+				RestAssuredOperationPreprocessorsConfigurer>
+		implements Filter {
+
+	RestAssuredOperationPreprocessorsConfigurer(RestAssuredRestDocumentationConfigurer parent) {
+		super(parent);
+	}
+
+	@Override
+	public Response filter(FilterableRequestSpecification requestSpec,
+			FilterableResponseSpecification responseSpec, FilterContext context) {
+		return and().filter(requestSpec, responseSpec, context);
+	}
+}

--- a/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured3/RestAssuredRestDocumentationConfigurer.java
+++ b/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured3/RestAssuredRestDocumentationConfigurer.java
@@ -33,14 +33,19 @@ import org.springframework.restdocs.config.RestDocumentationConfigurer;
  * A REST Assured 3-specific {@link RestDocumentationConfigurer}.
  *
  * @author Andy Wilkinson
+ * @author Filip Hrisafov
  * @since 1.2.0
  */
 public final class RestAssuredRestDocumentationConfigurer extends
-		RestDocumentationConfigurer<RestAssuredSnippetConfigurer, RestAssuredRestDocumentationConfigurer>
+		RestDocumentationConfigurer<RestAssuredSnippetConfigurer, RestAssuredOperationPreprocessorsConfigurer,
+				RestAssuredRestDocumentationConfigurer>
 		implements Filter {
 
 	private final RestAssuredSnippetConfigurer snippetConfigurer = new RestAssuredSnippetConfigurer(
 			this);
+
+	private final RestAssuredOperationPreprocessorsConfigurer operationPreprocessorsConfigurer =
+			new RestAssuredOperationPreprocessorsConfigurer(this);
 
 	private final RestDocumentationContextProvider contextProvider;
 
@@ -52,6 +57,11 @@ public final class RestAssuredRestDocumentationConfigurer extends
 	@Override
 	public RestAssuredSnippetConfigurer snippets() {
 		return this.snippetConfigurer;
+	}
+
+	@Override
+	public RestAssuredOperationPreprocessorsConfigurer operationPreprocessors() {
+		return this.operationPreprocessorsConfigurer;
 	}
 
 	@Override

--- a/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured3/RestDocumentationFilter.java
+++ b/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured3/RestDocumentationFilter.java
@@ -97,6 +97,10 @@ public class RestDocumentationFilter implements Filter {
 						context);
 				configuration.remove(
 						RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_SNIPPETS);
+				configuration.remove(
+						RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_REQUEST_PREPROCESSOR);
+				configuration.remove(
+						RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_RESPONSE_PREPROCESSOR);
 				return configuration;
 			}
 

--- a/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/RestAssuredRestDocumentationConfigurerTests.java
+++ b/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/RestAssuredRestDocumentationConfigurerTests.java
@@ -28,6 +28,9 @@ import org.mockito.ArgumentCaptor;
 
 import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.restdocs.generate.RestDocumentationGenerator;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
 import org.springframework.restdocs.snippet.WriterResolver;
 import org.springframework.restdocs.templates.TemplateEngine;
 
@@ -43,6 +46,7 @@ import static org.mockito.Mockito.verify;
  * Tests for {@link RestAssuredRestDocumentationConfigurer}.
  *
  * @author Andy Wilkinson
+ * @author Filip Hrisafov
  */
 public class RestAssuredRestDocumentationConfigurerTests {
 
@@ -68,7 +72,11 @@ public class RestAssuredRestDocumentationConfigurerTests {
 
 	@Test
 	public void configurationIsAddedToTheContext() {
-		this.configurer.filter(this.requestSpec, this.responseSpec, this.filterContext);
+		this.configurer
+				.operationPreprocessors()
+				.withDefaultRequestPreprocessors(Preprocessors.prettyPrint())
+				.withDefaultResponsePreprocessors(Preprocessors.removeHeaders("Foo"))
+				.filter(this.requestSpec, this.responseSpec, this.filterContext);
 		@SuppressWarnings("rawtypes")
 		ArgumentCaptor<Map> configurationCaptor = ArgumentCaptor.forClass(Map.class);
 		verify(this.filterContext).setValue(
@@ -84,5 +92,13 @@ public class RestAssuredRestDocumentationConfigurerTests {
 				hasEntry(
 						equalTo(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_SNIPPETS),
 						instanceOf(List.class)));
+		assertThat(configuration,
+				hasEntry(
+						equalTo(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_REQUEST_PREPROCESSOR),
+						instanceOf(OperationRequestPreprocessor.class)));
+		assertThat(configuration,
+				hasEntry(
+						equalTo(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_RESPONSE_PREPROCESSOR),
+						instanceOf(OperationResponsePreprocessor.class)));
 	}
 }


### PR DESCRIPTION
Fixes #419.

This PR adds the functionality for configuring default preprocessors for Requests and Responses. 

There are some `TODO`s in the changes as I was not sure about some things:

* 2 `TODO`s are for the tests. I couldn't think of a way to unit test that the preprocessors that are set are the ones we set.
* The 3rd `TODO` is more of a question that I had. Do we need to add something in the `RestDocumentationResultHandler`, and additionally I noticed that the Javadoc of that method does not correspond to the behaviour of the method.

Do we need to add something to the guide as well? If yes, I would do that once we agree on the implementation and the signatures for the API