### PR TITLE
Reuse ObjectMapper in FieldPathPayloadSubsectionExtractor

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractor.java
@@ -36,6 +36,8 @@ import org.springframework.restdocs.payload.JsonFieldProcessor.ExtractedField;
 public class FieldPathPayloadSubsectionExtractor
 		implements PayloadSubsectionExtractor<FieldPathPayloadSubsectionExtractor> {
 
+	private static final ObjectMapper objectMapper = new ObjectMapper();
+
 	private final String fieldPath;
 
 	private final String subsectionId;
@@ -66,7 +68,6 @@ public class FieldPathPayloadSubsectionExtractor
 
 	@Override
 	public byte[] extractSubsection(byte[] payload, MediaType contentType) {
-		ObjectMapper objectMapper = new ObjectMapper();
 		try {
 			ExtractedField extractedField = new JsonFieldProcessor().extract(
 					this.fieldPath, objectMapper.readValue(payload, Object.class));


### PR DESCRIPTION
This PR makes `FieldPathPayloadSubsectionExtractor` reuse `ObjectMapper`.

I originally created #430 for this but closed it because making it a field won't work. Making it `static` will work, so I reopen this. I tried to reopen #430 after force push but it looks impossible to reopen a PR after force push in GitHub.