### PR TITLE
Add linkWithSelfRel

### DIFF
--- a/docs/src/docs/asciidoc/documenting-your-api.adoc
+++ b/docs/src/docs/asciidoc/documenting-your-api.adoc
@@ -22,6 +22,8 @@ include::{examples-dir}/com/example/mockmvc/Hypermedia.java[tag=links]
 <2> Expect a link whose rel is `alpha`. Uses the static `linkWithRel` method on
 	`org.springframework.restdocs.hypermedia.HypermediaDocumentation`.
 <3> Expect a link whose rel is `bravo`.
+<4> Expect a `self` link. Uses the static `linkWithSelfRel` method on
+    `org.springframework.restdocs.hypermedia.HypermediaDocumentation`.
 
 [source,java,indent=0,role="secondary"]
 .REST Assured
@@ -34,6 +36,8 @@ include::{examples-dir}/com/example/restassured/Hypermedia.java[tag=links]
 <2> Expect a link whose rel is `alpha`. Uses the static `linkWithRel` method on
 	`org.springframework.restdocs.hypermedia.HypermediaDocumentation`.
 <3> Expect a link whose rel is `bravo`.
+<4> Expect a `self` link. Uses the static `linkWithSelfRel` method on
+    `org.springframework.restdocs.hypermedia.HypermediaDocumentation`.
 
 The result is a snippet named `links.adoc` that contains a table describing the resource's
 links.
@@ -94,7 +98,7 @@ response.
 [[documenting-your-api-hypermedia-ignoring-common-links]]
 ==== Ignoring common links
 
-Rather than documenting links that are common to every response, such as `_self` and
+Rather than documenting links that are common to every response, such as `self` and
 `curies` when using HAL, you may want to document them once in an overview section and
 then ignore them in the rest of your API's documentation. To do so, you can build on the
 <<documenting-your-api-reusing-snippets,support for reusing snippets>> to add link

--- a/docs/src/test/java/com/example/Hypermedia.java
+++ b/docs/src/test/java/com/example/Hypermedia.java
@@ -21,12 +21,13 @@ import org.springframework.restdocs.hypermedia.LinkDescriptor;
 import org.springframework.restdocs.hypermedia.LinksSnippet;
 
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithSelfRel;
 
 public class Hypermedia {
 
 	// tag::ignore-links[]
 	public static LinksSnippet links(LinkDescriptor... descriptors) {
-		return HypermediaDocumentation.links(linkWithRel("_self").ignored().optional(),
+		return HypermediaDocumentation.links(linkWithSelfRel().ignored().optional(),
 				linkWithRel("curies").ignored()).and(descriptors);
 	}
 	// end::ignore-links[]

--- a/docs/src/test/java/com/example/mockmvc/EveryTestPreprocessing.java
+++ b/docs/src/test/java/com/example/mockmvc/EveryTestPreprocessing.java
@@ -24,7 +24,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithSelfRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -65,7 +65,7 @@ public class EveryTestPreprocessing {
 		this.mockMvc.perform(get("/")) // <1>
 				.andExpect(status().isOk())
 				.andDo(this.documentationHandler.document( // <2>
-						links(linkWithRel("self").description("Canonical self link"))
+						links(linkWithSelfRel().description("Canonical self link"))
 				));
 		// end::use[]
 	}

--- a/docs/src/test/java/com/example/mockmvc/Hypermedia.java
+++ b/docs/src/test/java/com/example/mockmvc/Hypermedia.java
@@ -16,6 +16,7 @@
 
 package com.example.mockmvc;
 
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithSelfRel;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
@@ -36,7 +37,8 @@ public class Hypermedia {
 			.andExpect(status().isOk())
 			.andDo(document("index", links( // <1>
 					linkWithRel("alpha").description("Link to the alpha resource"), // <2>
-					linkWithRel("bravo").description("Link to the bravo resource")))); // <3>
+					linkWithRel("bravo").description("Link to the bravo resource"), // <3>
+					linkWithSelfRel().description("Link to the self resource")))); // <4>
 		// end::links[]
 	}
 
@@ -46,7 +48,8 @@ public class Hypermedia {
 			//tag::explicit-extractor[]
 			.andDo(document("index", links(halLinks(), // <1>
 					linkWithRel("alpha").description("Link to the alpha resource"),
-					linkWithRel("bravo").description("Link to the bravo resource"))));
+					linkWithRel("bravo").description("Link to the bravo resource"),
+					linkWithSelfRel().description("Link to the self resource"))));
 			// end::explicit-extractor[]
 	}
 

--- a/docs/src/test/java/com/example/restassured/EveryTestPreprocessing.java
+++ b/docs/src/test/java/com/example/restassured/EveryTestPreprocessing.java
@@ -26,7 +26,7 @@ import org.springframework.restdocs.JUnitRestDocumentation;
 import org.springframework.restdocs.restassured3.RestDocumentationFilter;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithSelfRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
@@ -62,7 +62,7 @@ public class EveryTestPreprocessing {
 		// tag::use[]
 		RestAssured.given(this.spec) // <1>
 			.filter(this.documentationFilter.document( // <2>
-					links(linkWithRel("self").description("Canonical self link"))))
+					links(linkWithSelfRel().description("Canonical self link"))))
 			.when().get("/")
 			.then().assertThat().statusCode(is(200));
 		// end::use[]

--- a/docs/src/test/java/com/example/restassured/Hypermedia.java
+++ b/docs/src/test/java/com/example/restassured/Hypermedia.java
@@ -22,6 +22,7 @@ import io.restassured.specification.RequestSpecification;
 import static org.hamcrest.CoreMatchers.is;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.halLinks;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithSelfRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
@@ -35,7 +36,8 @@ public class Hypermedia {
 			.accept("application/json")
 			.filter(document("index", links( // <1>
 					linkWithRel("alpha").description("Link to the alpha resource"), // <2>
-					linkWithRel("bravo").description("Link to the bravo resource")))) // <3>
+					linkWithRel("bravo").description("Link to the bravo resource"), // <3>
+					linkWithSelfRel().description("Link to the self resource")))) // <4>
 			.get("/").then().assertThat().statusCode(is(200));
 		// end::links[]
 	}
@@ -46,7 +48,8 @@ public class Hypermedia {
 		// tag::explicit-extractor[]
 		.filter(document("index", links(halLinks(), // <1>
 				linkWithRel("alpha").description("Link to the alpha resource"),
-				linkWithRel("bravo").description("Link to the bravo resource"))))
+				linkWithRel("bravo").description("Link to the bravo resource"),
+				linkWithSelfRel().description("Link to the self resource"))))
 		// end::explicit-extractor[]
 		.get("/").then().assertThat().statusCode(is(200));
 	}

--- a/samples/rest-notes-slate/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-slate/src/test/java/com/example/notes/ApiDocumentation.java
@@ -19,6 +19,7 @@ package com.example.notes;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithSelfRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -199,7 +200,7 @@ public class ApiDocumentation {
 			.andExpect(jsonPath("_links.tags", is(notNullValue())))
 			.andDo(document("note-get-example",
 					links(
-							linkWithRel("self").description("Canonical link for this resource"),
+							linkWithSelfRel().description("Canonical link for this resource"),
 							linkWithRel("note").description("This note"),
 							linkWithRel("tags").description("This note's tags")),
 					responseFields(
@@ -299,7 +300,7 @@ public class ApiDocumentation {
 			.andExpect(jsonPath("name", is(tag.get("name"))))
 			.andDo(document("tag-get-example",
 					links(
-							linkWithRel("self").description("Canonical link for this resource"),
+							linkWithSelfRel().description("Canonical link for this resource"),
 							linkWithRel("tag").description("This tag"),
 							linkWithRel("notes").description("The notes that have this tag")),
 					responseFields(

--- a/samples/rest-notes-spring-data-rest/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-spring-data-rest/src/test/java/com/example/notes/ApiDocumentation.java
@@ -19,6 +19,7 @@ package com.example.notes;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithSelfRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -133,7 +134,7 @@ public class ApiDocumentation {
 			.andExpect(status().isOk())
 			.andDo(document("notes-list-example",
 					links(
-							linkWithRel("self").description("Canonical link for this resource"),
+							linkWithSelfRel().description("Canonical link for this resource"),
 							linkWithRel("profile").description("The ALPS profile for this resource")),
 					responseFields(
 							subsectionWithPath("_embedded.notes").description("An array of <<resources-note, Note resources>>"),
@@ -201,7 +202,7 @@ public class ApiDocumentation {
 			.andDo(print())
 			.andDo(document("note-get-example",
 					links(
-							linkWithRel("self").description("Canonical link for this <<resources-note,note>>"),
+							linkWithSelfRel().description("Canonical link for this <<resources-note,note>>"),
 							linkWithRel("note").description("This <<resources-note,note>>"),
 							linkWithRel("tags").description("This note's tags")),
 					responseFields(
@@ -223,7 +224,7 @@ public class ApiDocumentation {
 			.andExpect(status().isOk())
 			.andDo(document("tags-list-example",
 					links(
-							linkWithRel("self").description("Canonical link for this resource"),
+							linkWithSelfRel().description("Canonical link for this resource"),
 							linkWithRel("profile").description("The ALPS profile for this resource")),
 					responseFields(
 							subsectionWithPath("_embedded.tags").description("An array of <<resources-tag,Tag resources>>"),
@@ -304,7 +305,7 @@ public class ApiDocumentation {
 			.andExpect(jsonPath("name", is(tag.get("name"))))
 			.andDo(document("tag-get-example",
 					links(
-							linkWithRel("self").description("Canonical link for this <<resources-tag,tag>>"),
+							linkWithSelfRel().description("Canonical link for this <<resources-tag,tag>>"),
 							linkWithRel("tag").description("This <<resources-tag,tag>>"),
 							linkWithRel("notes").description("The <<resources-tagged-notes,notes>> that have this tag")),
 					responseFields(

--- a/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java
@@ -21,6 +21,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.responseHeaders;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithRel;
+import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.linkWithSelfRel;
 import static org.springframework.restdocs.hypermedia.HypermediaDocumentation.links;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
@@ -223,7 +224,7 @@ public class ApiDocumentation {
 			.andExpect(jsonPath("_links.note-tags", is(notNullValue())))
 			.andDo(this.documentationHandler.document(
 				links(
-					linkWithRel("self").description("This <<resources-note,note>>"),
+					linkWithSelfRel().description("This <<resources-note,note>>"),
 					linkWithRel("note-tags").description("This note's <<resources-note-tags,tags>>")),
 				responseFields(
 					fieldWithPath("title").description("The title of the note"),
@@ -339,7 +340,7 @@ public class ApiDocumentation {
 			.andExpect(jsonPath("name", is(tag.get("name"))))
 			.andDo(this.documentationHandler.document(
 				links(
-					linkWithRel("self").description("This <<resources-tag,tag>>"),
+					linkWithSelfRel().description("This <<resources-tag,tag>>"),
 					linkWithRel("tagged-notes").description("The <<resources-tagged-notes,notes>> that have this tag")),
 				responseFields(
 					fieldWithPath("name").description("The name of the tag"),

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HypermediaDocumentation.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HypermediaDocumentation.java
@@ -43,6 +43,15 @@ public abstract class HypermediaDocumentation {
 	}
 
 	/**
+	 * Creates a {@code LinkDescriptor} that describes a link a self {@code rel}.
+	 *
+	 * @return a {@code LinkDescriptor} ready for further configuration
+	 */
+	public static LinkDescriptor linkWithSelfRel() {
+		return new LinkDescriptor("self");
+	}
+
+	/**
 	 * Returns a new {@code Snippet} that will document the links in the API operation's
 	 * response. Links will be extracted from the response automatically based on its
 	 * content type and will be documented using the given {@code descriptors}.


### PR DESCRIPTION
Adds `linkWithSelfRel` to `HypermediaDocumentation` as a convenience method in place of `linkWithRel("self")` due to its abundance