### PR TITLE
Query parameters with multiple values are not handled correctly when using REST Assured

### DIFF
--- a/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured3/RestAssuredRequestConverter.java
+++ b/spring-restdocs-restassured/src/main/java/org/springframework/restdocs/restassured3/RestAssuredRequestConverter.java
@@ -140,7 +140,15 @@ class RestAssuredRequestConverter
 	private Parameters extractParameters(FilterableRequestSpecification requestSpec) {
 		Parameters parameters = new Parameters();
 		for (Entry<String, ?> entry : requestSpec.getQueryParams().entrySet()) {
-			parameters.add(entry.getKey(), entry.getValue().toString());
+			if (entry.getValue() instanceof Collection) {
+				Collection queryParams = ((Collection) entry.getValue());
+				for (Object queryParam : queryParams) {
+					parameters.add(entry.getKey(), queryParam.toString());
+				}
+			}
+			else {
+				parameters.add(entry.getKey(), entry.getValue().toString());
+			}
 		}
 		for (Entry<String, ?> entry : requestSpec.getRequestParams().entrySet()) {
 			parameters.add(entry.getKey(), entry.getValue().toString());

--- a/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/RestAssuredRequestConverterTests.java
+++ b/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/RestAssuredRequestConverterTests.java
@@ -91,11 +91,11 @@ public class RestAssuredRequestConverterTests {
 	@Test
 	public void queryStringFromUrlParameters() {
 		RequestSpecification requestSpec = RestAssured.given().port(tomcat.getPort());
-		requestSpec.get("/?foo=bar");
+		requestSpec.get("/?foo=bar&foo=qix");
 		OperationRequest request = this.factory
 				.convert((FilterableRequestSpecification) requestSpec);
 		assertThat(request.getParameters().size(), is(1));
-		assertThat(request.getParameters().get("foo"), is(equalTo(Arrays.asList("bar"))));
+		assertThat(request.getParameters().get("foo"), is(equalTo(Arrays.asList("bar", "qix"))));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes gh-476