### PR TITLE
asciidocs cols seems to require quotes

### DIFF
--- a/docs/src/docs/asciidoc/working-with-asciidoctor.adoc
+++ b/docs/src/docs/asciidoc/working-with-asciidoctor.adoc
@@ -136,7 +136,7 @@ example, the widths of a table's columns can be specified using the `cols` attri
 
 [source,indent=0]
 ----
-[cols=1,3] <1>
+[cols="1,3"] <1>
 \include::{snippets}/index/links.adoc[]
 ----
 <1> The table's width will be split across its two columns with the second column being


### PR DESCRIPTION
While the [oficial asciidoctor.org reference for tables](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#tables) seems a bit ambiguous and does not use quotes for the `cols` attribute all the time, it seems that quotes are required for the example of `[cols="1,3"]`in Line 139

My setup:
spring-restdocs 2.0.0.RELEASE, Gradle plugin `"org.asciidoctor.convert" version "1.5.3`, Spring Boot 2.0.0.RC1, Java 9, Ubuntu