### PR TITLE
Make AbstractJsonLinkExtractor public

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/AbstractJsonLinkExtractor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/AbstractJsonLinkExtractor.java
@@ -29,7 +29,7 @@ import org.springframework.restdocs.operation.OperationResponse;
  *
  * @author Andy Wilkinson
  */
-abstract class AbstractJsonLinkExtractor implements LinkExtractor {
+public abstract class AbstractJsonLinkExtractor implements LinkExtractor {
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
 

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/AbstractJsonLinkExtractor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/AbstractJsonLinkExtractor.java
@@ -42,6 +42,12 @@ public abstract class AbstractJsonLinkExtractor implements LinkExtractor {
 		return extractLinks(jsonContent);
 	}
 
+	/**
+	 * The method to implement for JSON LinkExtractors which does the actual extraction.
+	 *
+	 * @param json The JSON data formatted as a Map of Strings to Objects
+	 * @return The extracted links, keyed by rel
+	 */
 	protected abstract Map<String, List<Link>> extractLinks(Map<String, Object> json);
 
 }


### PR DESCRIPTION
I believe this abstract class should be public. As a user of Restdocs I want to make my own LinkExtractor that extracts links from JSON, but which finds them in a different location than the `AtomLinkExtractor` or `HalLinkExtractor`. 

It seems like overkill to make clients re-implement the logic to find links from JSON formatted responses.