### PR TITLE
Curl snippet may use incorrect HTTP method for GET requests with a body

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlRequestSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/cli/CurlRequestSnippet.java
@@ -105,7 +105,7 @@ public class CurlRequestSnippet extends TemplatedSnippet {
 
 		CliOperationRequest request = new CliOperationRequest(operation.getRequest());
 		writeUserOptionIfNecessary(request, builder);
-		writeHttpMethodIfNecessary(request, builder);
+		writeHttpMethod(request, builder);
 
 		List<String> additionalLines = new ArrayList<>();
 		writeHeaders(request, additionalLines);
@@ -144,11 +144,9 @@ public class CurlRequestSnippet extends TemplatedSnippet {
 		}
 	}
 
-	private void writeHttpMethodIfNecessary(OperationRequest request,
+	private void writeHttpMethod(OperationRequest request,
 			StringBuilder builder) {
-		if (!HttpMethod.GET.equals(request.getMethod())) {
-			builder.append(String.format(" -X %s", request.getMethod()));
-		}
+		builder.append(String.format(" -X %s", request.getMethod()));
 	}
 
 	private void writeHeaders(CliOperationRequest request, List<String> lines) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/cli/CurlRequestSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/cli/CurlRequestSnippetTests.java
@@ -59,7 +59,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	@Test
 	public void getRequest() throws IOException {
 		this.snippets.expectCurlRequest().withContents(
-				codeBlock("bash").content("$ curl 'http://localhost/foo' -i"));
+				codeBlock("bash").content("$ curl 'http://localhost/foo' -i -X GET"));
 		new CurlRequestSnippet(this.commandFormatter)
 				.document(this.operationBuilder.request("http://localhost/foo").build());
 	}
@@ -67,7 +67,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	@Test
 	public void getRequestWithParameter() throws IOException {
 		this.snippets.expectCurlRequest().withContents(
-				codeBlock("bash").content("$ curl 'http://localhost/foo?a=alpha' -i"));
+				codeBlock("bash").content("$ curl 'http://localhost/foo?a=alpha' -i -X GET"));
 		new CurlRequestSnippet(this.commandFormatter).document(this.operationBuilder
 				.request("http://localhost/foo").param("a", "alpha").build());
 	}
@@ -81,9 +81,17 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
-	public void requestWithContent() throws IOException {
+	public void postRequestWithContent() throws IOException {
 		this.snippets.expectCurlRequest().withContents(codeBlock("bash")
-				.content("$ curl 'http://localhost/foo' -i -d 'content'"));
+				.content("$ curl 'http://localhost/foo' -i -X POST -d 'content'"));
+		new CurlRequestSnippet(this.commandFormatter).document(this.operationBuilder
+				.request("http://localhost/foo").method("POST").content("content").build());
+	}
+
+	@Test
+	public void getRequestWithContent() throws IOException {
+		this.snippets.expectCurlRequest().withContents(codeBlock("bash")
+				.content("$ curl 'http://localhost/foo' -i -X GET -d 'content'"));
 		new CurlRequestSnippet(this.commandFormatter).document(this.operationBuilder
 				.request("http://localhost/foo").content("content").build());
 	}
@@ -91,7 +99,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	@Test
 	public void getRequestWithQueryString() throws IOException {
 		this.snippets.expectCurlRequest().withContents(codeBlock("bash")
-				.content("$ curl 'http://localhost/foo?param=value' -i"));
+				.content("$ curl 'http://localhost/foo?param=value' -i -X GET"));
 		new CurlRequestSnippet(this.commandFormatter).document(this.operationBuilder
 				.request("http://localhost/foo?param=value").build());
 	}
@@ -100,7 +108,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	public void getRequestWithTotallyOverlappingQueryStringAndParameters()
 			throws IOException {
 		this.snippets.expectCurlRequest().withContents(codeBlock("bash")
-				.content("$ curl 'http://localhost/foo?param=value' -i"));
+				.content("$ curl 'http://localhost/foo?param=value' -i -X GET"));
 		new CurlRequestSnippet(this.commandFormatter).document(
 				this.operationBuilder.request("http://localhost/foo?param=value")
 						.param("param", "value").build());
@@ -110,7 +118,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	public void getRequestWithPartiallyOverlappingQueryStringAndParameters()
 			throws IOException {
 		this.snippets.expectCurlRequest().withContents(codeBlock("bash")
-				.content("$ curl 'http://localhost/foo?a=alpha&b=bravo' -i"));
+				.content("$ curl 'http://localhost/foo?a=alpha&b=bravo' -i -X GET"));
 		new CurlRequestSnippet(this.commandFormatter)
 				.document(this.operationBuilder.request("http://localhost/foo?a=alpha")
 						.param("a", "alpha").param("b", "bravo").build());
@@ -119,7 +127,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	@Test
 	public void getRequestWithDisjointQueryStringAndParameters() throws IOException {
 		this.snippets.expectCurlRequest().withContents(codeBlock("bash")
-				.content("$ curl 'http://localhost/foo?a=alpha&b=bravo' -i"));
+				.content("$ curl 'http://localhost/foo?a=alpha&b=bravo' -i -X GET"));
 		new CurlRequestSnippet(this.commandFormatter).document(this.operationBuilder
 				.request("http://localhost/foo?a=alpha").param("b", "bravo").build());
 	}
@@ -127,7 +135,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	@Test
 	public void getRequestWithQueryStringWithNoValue() throws IOException {
 		this.snippets.expectCurlRequest().withContents(
-				codeBlock("bash").content("$ curl 'http://localhost/foo?param' -i"));
+				codeBlock("bash").content("$ curl 'http://localhost/foo?param' -i -X GET"));
 		new CurlRequestSnippet(this.commandFormatter).document(
 				this.operationBuilder.request("http://localhost/foo?param").build());
 	}
@@ -245,7 +253,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	@Test
 	public void requestWithHeaders() throws IOException {
 		this.snippets.expectCurlRequest()
-				.withContents(codeBlock("bash").content("$ curl 'http://localhost/foo' -i"
+				.withContents(codeBlock("bash").content("$ curl 'http://localhost/foo' -i -X GET"
 						+ " -H 'Content-Type: application/json' -H 'a: alpha'"));
 		new CurlRequestSnippet(this.commandFormatter)
 				.document(this.operationBuilder.request("http://localhost/foo")
@@ -258,7 +266,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	public void requestWithHeadersMultiline() throws IOException {
 		this.snippets.expectCurlRequest()
 				.withContents(codeBlock("bash")
-						.content(String.format("$ curl 'http://localhost/foo' -i \\%n"
+						.content(String.format("$ curl 'http://localhost/foo' -i -X GET \\%n"
 								+ "    -H 'Content-Type: application/json' \\%n"
 								+ "    -H 'a: alpha'")));
 		new CurlRequestSnippet(CliDocumentation.multiLineFormat())
@@ -271,7 +279,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	@Test
 	public void requestWithCookies() throws IOException {
 		this.snippets.expectCurlRequest()
-				.withContents(codeBlock("bash").content("$ curl 'http://localhost/foo' -i"
+				.withContents(codeBlock("bash").content("$ curl 'http://localhost/foo' -i -X GET"
 						+ " --cookie 'name1=value1;name2=value2'"));
 		new CurlRequestSnippet(this.commandFormatter)
 				.document(this.operationBuilder.request("http://localhost/foo")
@@ -343,7 +351,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	@Test
 	public void basicAuthCredentialsAreSuppliedUsingUserOption() throws IOException {
 		this.snippets.expectCurlRequest().withContents(codeBlock("bash")
-				.content("$ curl 'http://localhost/foo' -i -u 'user:secret'"));
+				.content("$ curl 'http://localhost/foo' -i -u 'user:secret' -X GET"));
 		new CurlRequestSnippet(this.commandFormatter)
 				.document(this.operationBuilder.request("http://localhost/foo")
 						.header(HttpHeaders.AUTHORIZATION,
@@ -373,7 +381,7 @@ public class CurlRequestSnippetTests extends AbstractSnippetTests {
 	public void customHostHeaderIsIncluded() throws IOException {
 		this.snippets.expectCurlRequest()
 				.withContents(codeBlock("bash").content(
-						"$ curl 'http://localhost/foo' -i" + " -H 'Host: api.example.com'"
+						"$ curl 'http://localhost/foo' -i -X GET" + " -H 'Host: api.example.com'"
 								+ " -H 'Content-Type: application/json' -H 'a: alpha'"));
 		new CurlRequestSnippet(this.commandFormatter)
 				.document(this.operationBuilder.request("http://localhost/foo")

--- a/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcRestDocumentationIntegrationTests.java
+++ b/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcRestDocumentationIntegrationTests.java
@@ -182,7 +182,7 @@ public class MockMvcRestDocumentationIntegrationTests {
 				new File(
 						"build/generated-snippets/curl-snippet-with-cookies/curl-request.adoc"),
 				is(snippet(asciidoctor()).withContents(codeBlock(asciidoctor(), "bash")
-						.content(String.format("$ curl 'http://localhost:8080/' -i \\%n"
+						.content(String.format("$ curl 'http://localhost:8080/' -i -X GET \\%n"
 								+ "    -H 'Accept: application/json' \\%n"
 								+ "    --cookie 'cookieName=cookieVal'")))));
 	}
@@ -633,7 +633,7 @@ public class MockMvcRestDocumentationIntegrationTests {
 						"build/generated-snippets/custom-context-path/curl-request.adoc"),
 				is(snippet(asciidoctor())
 						.withContents(codeBlock(asciidoctor(), "bash").content(String
-								.format("$ curl 'http://localhost:8080/custom/' -i \\%n"
+								.format("$ curl 'http://localhost:8080/custom/' -i -X GET \\%n"
 										+ "    -H 'Accept: application/json'")))));
 	}
 

--- a/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/RestAssuredRestDocumentationIntegrationTests.java
+++ b/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/RestAssuredRestDocumentationIntegrationTests.java
@@ -123,7 +123,7 @@ public class RestAssuredRestDocumentationIntegrationTests {
 						"build/generated-snippets/curl-snippet-with-cookies/curl-request.adoc"),
 				is(snippet(asciidoctor()).withContents(codeBlock(asciidoctor(),
 						"bash").content(String.format("$ curl 'http://localhost:"
-								+ tomcat.getPort() + "/' -i \\%n"
+								+ tomcat.getPort() + "/' -i -X GET \\%n"
 								+ "    -H 'Accept: application/json' \\%n"
 								+ "    -H 'Content-Type: " + contentType + "' \\%n"
 								+ "    --cookie 'cookieName=cookieVal'")))));

--- a/spring-restdocs-webtestclient/src/test/java/org/springframework/restdocs/webtestclient/WebTestClientRestDocumentationIntegrationTests.java
+++ b/spring-restdocs-webtestclient/src/test/java/org/springframework/restdocs/webtestclient/WebTestClientRestDocumentationIntegrationTests.java
@@ -180,7 +180,7 @@ public class WebTestClientRestDocumentationIntegrationTests {
 				new File(
 						"build/generated-snippets/curl-snippet-with-cookies/curl-request.adoc"),
 				is(snippet(asciidoctor()).withContents(codeBlock(asciidoctor(), "bash")
-						.content(String.format("$ curl 'https://api.example.com/' -i \\%n"
+						.content(String.format("$ curl 'https://api.example.com/' -i -X GET \\%n"
 								+ "    -H 'Accept: application/json' \\%n"
 								+ "    --cookie 'cookieName=cookieVal'")))));
 	}


### PR DESCRIPTION
With `-d` option, `curl` assumes its method is `POST`, so `GET` method with `-d` option is changed to `POST` method now.

This PR changes to add `-X GET` when `curl` command has `-d` option although its method is `GET`.

I didn't change to omit `-X POST` with `-d` option intentionally as it triggers to change many tests but if the change is preferred, I can update this PR to do that. 