### PR TITLE
Add urlTemplate model property to allow more generic request doc

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
@@ -78,6 +78,9 @@ public class HttpRequestSnippet extends TemplatedSnippet {
 		if (urlTemplate != null) {
 			model.put("urlTemplate", urlTemplate);
 		}
+		else {
+			model.put("urlTemplate", "");
+		}
 
 		return model;
 	}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
@@ -27,6 +27,7 @@ import java.util.Map.Entry;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.generate.RestDocumentationGenerator;
 import org.springframework.restdocs.operation.Operation;
 import org.springframework.restdocs.operation.OperationRequest;
 import org.springframework.restdocs.operation.OperationRequestPart;
@@ -71,6 +72,13 @@ public class HttpRequestSnippet extends TemplatedSnippet {
 		model.put("path", getPath(operation.getRequest()));
 		model.put("headers", getHeaders(operation.getRequest()));
 		model.put("requestBody", getRequestBody(operation.getRequest()));
+
+		String urlTemplate = extractUrlTemplate(operation);
+
+		if (urlTemplate != null) {
+			model.put("urlTemplate", urlTemplate);
+		}
+
 		return model;
 	}
 
@@ -214,6 +222,25 @@ public class HttpRequestSnippet extends TemplatedSnippet {
 		header.put("name", name);
 		header.put("value", value);
 		return header;
+	}
+
+	private String extractUrlTemplate(Operation operation) {
+		String urlTemplate = (String) operation.getAttributes()
+				.get(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE);
+
+		if (urlTemplate != null) {
+			urlTemplate = removeQueryStringIfPresent(urlTemplate);
+		}
+
+		return urlTemplate;
+	}
+
+	private String removeQueryStringIfPresent(String urlTemplate) {
+		int index = urlTemplate.indexOf('?');
+		if (index == -1) {
+			return urlTemplate;
+		}
+		return urlTemplate.substring(0, index);
 	}
 
 }

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/http/HttpRequestSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/http/HttpRequestSnippetTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.AbstractSnippetTests;
+import org.springframework.restdocs.generate.RestDocumentationGenerator;
 import org.springframework.restdocs.templates.TemplateEngine;
 import org.springframework.restdocs.templates.TemplateFormat;
 import org.springframework.restdocs.templates.TemplateResourceResolver;
@@ -133,6 +134,21 @@ public class HttpRequestSnippetTests extends AbstractSnippetTests {
 		new HttpRequestSnippet().document(
 				this.operationBuilder.request("http://localhost/foo?a=alpha&b=bravo")
 						.param("a", "alpha").param("b", "bravo").build());
+	}
+
+	@Test
+	public void getRequestWithUrlTemplate() throws IOException {
+		this.snippets.expectHttpRequest().withContents(containsString("/{a}"));
+
+		TemplateResourceResolver resolver = mock(TemplateResourceResolver.class);
+		given(resolver.resolveTemplateResource("http-request"))
+				.willReturn(snippetResource("http-request-with-template"));
+
+		new HttpRequestSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, "/{a}")
+				.attribute(TemplateEngine.class.getName(),
+						new MustacheTemplateEngine(resolver))
+				.request("http://localhost/foo").header("Alpha", "a").build());
 	}
 
 	@Test

--- a/spring-restdocs-core/src/test/resources/custom-snippet-templates/asciidoctor/http-request-with-template.snippet
+++ b/spring-restdocs-core/src/test/resources/custom-snippet-templates/asciidoctor/http-request-with-template.snippet
@@ -1,0 +1,8 @@
+[source,http]
+----
+{{method}} {{urlTemplate}} HTTP/1.1
+{{#headers}}
+{{name}}: {{value}}
+{{/headers}}
+{{requestBody}}
+----

--- a/spring-restdocs-core/src/test/resources/custom-snippet-templates/markdown/http-request-with-template.snippet
+++ b/spring-restdocs-core/src/test/resources/custom-snippet-templates/markdown/http-request-with-template.snippet
@@ -1,0 +1,7 @@
+```http
+{{method}} {{urlTemplate}} HTTP/1.1
+{{#headers}}
+{{name}}: {{value}}
+{{/headers}}
+{{requestBody}}
+```


### PR DESCRIPTION
In many cases when documenting requests, it would be preferable to display the general form of a URL, as opposed to the specific form with IDs that was used to generate the documentation via MockMvc Rest Doc.

This request adds a "urlTemplate" model property to the default properties (borrowing from logic in PathParametersSnippet), so that generating using the template instead of the test path is simplified to overriding the http-request snippet in a consuming project