### PR TITLE
Add a snippet which documents defining properties of a request

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/request/RequestDocumentation.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/request/RequestDocumentation.java
@@ -35,6 +35,28 @@ public abstract class RequestDocumentation {
 	}
 
 	/**
+	 * Returns a new {@code Snippet} that will document the request URI for the API
+	 * operation.
+	 *
+	 * @return the snippet that will document the request URI
+	 */
+	public static RequestUriSnippet requestUri() {
+		return new RequestUriSnippet();
+	}
+
+	/**
+	 * Returns a new {@code Snippet} that will document the request URI for the API
+	 * operation. The given {@code attributes} will be available during snippet
+	 * generation.
+	 *
+	 * @param attributes the attributes
+	 * @return the snippet that will document the request URI
+	 */
+	public static RequestUriSnippet requestUri(Map<String, Object> attributes) {
+		return new RequestUriSnippet(attributes);
+	}
+
+	/**
 	 * Creates a {@link ParameterDescriptor} that describes a request or path parameter
 	 * with the given {@code name}.
 	 *

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/request/RequestUriSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/request/RequestUriSnippet.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2014-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.request;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.generate.RestDocumentationGenerator;
+import org.springframework.restdocs.operation.Operation;
+import org.springframework.restdocs.operation.OperationRequest;
+import org.springframework.restdocs.operation.RequestCookie;
+import org.springframework.restdocs.snippet.Snippet;
+import org.springframework.restdocs.snippet.TemplatedSnippet;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link Snippet} that documents the request URI supported by a RESTful resource.
+ *
+ * @author Ryan O'Meara
+ * @see RequestDocumentation#requestUri()
+ * @see RequestDocumentation#requestUri(Map)
+ */
+public class RequestUriSnippet extends TemplatedSnippet {
+
+	private static final String MULTIPART_BOUNDARY = "6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm";
+
+	/**
+	 * Creates a new {@code RequestUriSnippet} with no additional attributes.
+	 */
+	protected RequestUriSnippet() {
+		this(null);
+	}
+
+	/**
+	 * Creates a new {@code RequestUriSnippet} with the given additional
+	 * {@code attributes} that will be included in the model during template rendering.
+	 *
+	 * @param attributes The additional attributes
+	 */
+	protected RequestUriSnippet(Map<String, Object> attributes) {
+		super("request-uri", attributes);
+	}
+
+	@Override
+	protected Map<String, Object> createModel(Operation operation) {
+		Map<String, Object> model = new HashMap<>();
+		model.put("method", operation.getRequest().getMethod());
+		model.put("urlTemplate", getUrlTemplate(operation));
+		model.put("headers", getHeaders(operation.getRequest()));
+		return model;
+	}
+
+	private boolean includeParametersInUri(OperationRequest request) {
+		return request.getMethod() == HttpMethod.GET || request.getContent().length > 0;
+	}
+
+	private String getUrlTemplate(Operation operation) {
+		String urlTemplate = (String) operation.getAttributes()
+				.get(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE);
+		Assert.notNull(urlTemplate, "urlTemplate not found. If you are using MockMvc did "
+				+ "you use RestDocumentationRequestBuilders to build the request?");
+		return removeQueryStringIfPresent(urlTemplate);
+	}
+
+	private List<Map<String, String>> getHeaders(OperationRequest request) {
+		List<Map<String, String>> headers = new ArrayList<>();
+
+		for (Entry<String, List<String>> header : request.getHeaders().entrySet()) {
+			if (HttpHeaders.ACCEPT.equals(header.getKey())
+					|| HttpHeaders.CONTENT_TYPE.equals(header.getKey())) {
+				for (String value : header.getValue()) {
+					if (HttpHeaders.CONTENT_TYPE.equals(header.getKey())
+							&& !request.getParts().isEmpty()) {
+						headers.add(header(header.getKey(), String
+								.format("%s; boundary=%s", value, MULTIPART_BOUNDARY)));
+					}
+					else {
+						headers.add(header(header.getKey(), value));
+					}
+
+				}
+			}
+		}
+
+		for (RequestCookie cookie : request.getCookies()) {
+			headers.add(header(HttpHeaders.COOKIE,
+					String.format("%s=%s", cookie.getName(), cookie.getValue())));
+		}
+
+		if (requiresFormEncodingContentTypeHeader(request)) {
+			headers.add(header(HttpHeaders.CONTENT_TYPE,
+					MediaType.APPLICATION_FORM_URLENCODED_VALUE));
+		}
+		return headers;
+	}
+
+	private boolean isPutOrPost(OperationRequest request) {
+		return HttpMethod.PUT.equals(request.getMethod())
+				|| HttpMethod.POST.equals(request.getMethod());
+	}
+
+	private boolean requiresFormEncodingContentTypeHeader(OperationRequest request) {
+		return request.getHeaders().get(HttpHeaders.CONTENT_TYPE) == null
+				&& isPutOrPost(request) && (!request.getParameters().isEmpty()
+						&& !includeParametersInUri(request));
+	}
+
+	private Map<String, String> header(String name, String value) {
+		Map<String, String> header = new HashMap<>();
+		header.put("name", name);
+		header.put("value", value);
+		return header;
+	}
+
+	private String removeQueryStringIfPresent(String urlTemplate) {
+		int index = urlTemplate.indexOf('?');
+		if (index == -1) {
+			return urlTemplate;
+		}
+		return urlTemplate.substring(0, index);
+	}
+
+}

--- a/spring-restdocs-core/src/main/resources/org/springframework/restdocs/templates/asciidoctor/default-request-uri.snippet
+++ b/spring-restdocs-core/src/main/resources/org/springframework/restdocs/templates/asciidoctor/default-request-uri.snippet
@@ -1,0 +1,7 @@
+[source,http,options="nowrap"]
+----
+{{method}} {{urlTemplate}}
+{{#headers}}
+{{name}}: {{value}}
+{{/headers}}
+----

--- a/spring-restdocs-core/src/main/resources/org/springframework/restdocs/templates/markdown/default-request-uri.snippet
+++ b/spring-restdocs-core/src/main/resources/org/springframework/restdocs/templates/markdown/default-request-uri.snippet
@@ -1,0 +1,6 @@
+```http
+{{method}} {{urlTemplate}}
+{{#headers}}
+{{name}}: {{value}}
+{{/headers}}
+```

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/AbstractSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/AbstractSnippetTests.java
@@ -33,6 +33,7 @@ import org.springframework.restdocs.test.SnippetMatchers;
 import org.springframework.restdocs.test.SnippetMatchers.CodeBlockMatcher;
 import org.springframework.restdocs.test.SnippetMatchers.HttpRequestMatcher;
 import org.springframework.restdocs.test.SnippetMatchers.HttpResponseMatcher;
+import org.springframework.restdocs.test.SnippetMatchers.RequestUriMatcher;
 import org.springframework.restdocs.test.SnippetMatchers.TableMatcher;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -90,6 +91,10 @@ public abstract class AbstractSnippetTests {
 
 	public HttpResponseMatcher httpResponse(HttpStatus responseStatus) {
 		return SnippetMatchers.httpResponse(this.templateFormat, responseStatus);
+	}
+
+	public RequestUriMatcher requestUri(RequestMethod method, String urlTemplate) {
+		return SnippetMatchers.requestUri(this.templateFormat, method, urlTemplate);
 	}
 
 	protected FileSystemResource snippetResource(String name) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestUriSnippetFailureTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestUriSnippetFailureTests.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.request;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.restdocs.test.ExpectedSnippets;
+import org.springframework.restdocs.test.OperationBuilder;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.templates.TemplateFormats.asciidoctor;
+
+/**
+ * Tests for failures when rendering {@link RequestUriSnippet} due to missing parameters.
+ *
+ * @author Ryan O'Meara
+ */
+public class RequestUriSnippetFailureTests {
+
+	@Rule
+	public OperationBuilder operationBuilder = new OperationBuilder(asciidoctor());
+
+	@Rule
+	public ExpectedSnippets snippets = new ExpectedSnippets(asciidoctor());
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void missingPathParameter() throws IOException {
+		this.thrown.expect(IllegalArgumentException.class);
+		this.thrown.expectMessage(equalTo(
+				"urlTemplate not found. If you are using MockMvc did you use RestDocumentationRequestBuilders to build the request?"));
+		new PathParametersSnippet(
+				Arrays.asList(parameterWithName("a").description("one")))
+						.document(this.operationBuilder.build());
+	}
+
+}

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestUriSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestUriSnippetTests.java
@@ -71,8 +71,7 @@ public class RequestUriSnippetTests extends AbstractSnippetTests {
 				.request("http://localhost/foo").header("Alpha", "a").param("b", "bravo")
 				.build());
 	}
-
-	// TODO
+	
 	@Test
 	public void getRequestWithQueryString() throws IOException {
 		this.snippets.expectRequestUri()

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestUriSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestUriSnippetTests.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright 2014-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.request;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.AbstractSnippetTests;
+import org.springframework.restdocs.generate.RestDocumentationGenerator;
+import org.springframework.restdocs.templates.TemplateEngine;
+import org.springframework.restdocs.templates.TemplateFormat;
+import org.springframework.restdocs.templates.TemplateResourceResolver;
+import org.springframework.restdocs.templates.mustache.MustacheTemplateEngine;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+/**
+ * Tests for {@link RequestUriSnippet}.
+ *
+ * @author Ryan O'Meara
+ */
+public class RequestUriSnippetTests extends AbstractSnippetTests {
+
+	private static final String BOUNDARY = "6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm";
+
+	public RequestUriSnippetTests(String name, TemplateFormat templateFormat) {
+		super(name, templateFormat);
+	}
+
+	@Test
+	public void getRequest() throws IOException {
+		this.snippets.expectRequestUri().withContents(
+				requestUri(RequestMethod.GET, "/{a}/{b}").header("Accept", "a"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo/bar").header("Accept", "a").build());
+	}
+
+	@Test
+	public void getRequestWithParameters() throws IOException {
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.GET, "/{a}/{b}"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo").header("Alpha", "a").param("b", "bravo")
+				.build());
+	}
+
+	// TODO
+	@Test
+	public void getRequestWithQueryString() throws IOException {
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.GET, "/{a}/{b}"));
+
+		new RequestUriSnippet()
+				.document(this.operationBuilder
+						.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+								"/{a}/{b}")
+						.request("http://localhost/foo?bar=baz").build());
+	}
+
+	@Test
+	public void getRequestWithQueryStringWithNoValue() throws IOException {
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.GET, "/{a}/{b}"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo?bar").build());
+	}
+
+	@Test
+	public void getWithTotallyOverlappingQueryStringAndParameters() throws IOException {
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.GET, "/{a}/{b}"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo?a=alpha&b=bravo").param("a", "alpha")
+				.param("b", "bravo").build());
+	}
+
+	@Test
+	public void postRequestWithContent() throws IOException {
+		String content = "Hello, world";
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.POST, "/{a}/{b}"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo").method("POST").content(content).build());
+	}
+
+	@Test
+	public void postRequestWithContentAndParameters() throws IOException {
+		String content = "Hello, world";
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.POST, "/{a}/{b}"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo").method("POST").param("a", "alpha")
+				.content(content).build());
+	}
+
+	@Test
+	public void postRequestWithContentAndOverlappingQueryStringAndParameters()
+			throws IOException {
+		String content = "Hello, world";
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.POST, "/{a}/{b}"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo?b=bravo&a=alpha").method("POST")
+				.param("a", "alpha").param("b", "bravo").content(content).build());
+	}
+
+	@Test
+	public void postRequestWithCharset() throws IOException {
+		String japaneseContent = "\u30b3\u30f3\u30c6\u30f3\u30c4";
+		byte[] contentBytes = japaneseContent.getBytes("UTF-8");
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.POST, "/{a}/{b}")
+						.header("Content-Type", "text/plain;charset=UTF-8"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo").method("POST")
+				.header("Content-Type", "text/plain;charset=UTF-8").content(contentBytes)
+				.build());
+	}
+
+	@Test
+	public void postRequestWithParameter() throws IOException {
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.POST, "/{a}/{b}")
+						.header("Content-Type", "application/x-www-form-urlencoded"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo").method("POST").param("b&r", "baz")
+				.param("a", "alpha").build());
+	}
+
+	@Test
+	public void postRequestWithParameterWithNoValue() throws IOException {
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.POST, "/{a}/{b}")
+						.header("Content-Type", "application/x-www-form-urlencoded"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo").method("POST").param("bar").build());
+	}
+
+	@Test
+	public void putRequestWithContent() throws IOException {
+		String content = "Hello, world";
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.PUT, "/{a}/{b}"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo").method("PUT").content(content).build());
+	}
+
+	@Test
+	public void putRequestWithParameter() throws IOException {
+		this.snippets.expectRequestUri()
+				.withContents(requestUri(RequestMethod.PUT, "/{a}/{b}")
+						.header("Content-Type", "application/x-www-form-urlencoded"));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/foo").method("PUT").param("b&r", "baz")
+				.param("a", "alpha").build());
+	}
+
+	@Test
+	public void multipartPost() throws IOException {
+		this.snippets.expectRequestUri().withContents(
+				requestUri(RequestMethod.POST, "/{a}/{b}").header("Content-Type",
+						"multipart/form-data; boundary=" + BOUNDARY));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/upload").method("POST")
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE)
+				.part("image", "<< data >>".getBytes()).build());
+	}
+
+	@Test
+	public void multipartPostWithFilename() throws IOException {
+		this.snippets.expectRequestUri().withContents(
+				requestUri(RequestMethod.POST, "/{a}/{b}").header("Content-Type",
+						"multipart/form-data; boundary=" + BOUNDARY));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/upload").method("POST")
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE)
+				.part("image", "<< data >>".getBytes()).submittedFileName("image.png")
+				.build());
+	}
+
+	@Test
+	public void multipartPostWithParameters() throws IOException {
+		this.snippets.expectRequestUri().withContents(
+				requestUri(RequestMethod.POST, "/{a}/{b}").header("Content-Type",
+						"multipart/form-data; boundary=" + BOUNDARY));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/upload").method("POST")
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE)
+				.param("a", "apple", "avocado").param("b", "banana")
+				.part("image", "<< data >>".getBytes()).build());
+	}
+
+	@Test
+	public void multipartPostWithParameterWithNoValue() throws IOException {
+		this.snippets.expectRequestUri().withContents(
+				requestUri(RequestMethod.POST, "/{a}/{b}").header("Content-Type",
+						"multipart/form-data; boundary=" + BOUNDARY));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/upload").method("POST")
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE)
+				.param("a").part("image", "<< data >>".getBytes()).build());
+	}
+
+	@Test
+	public void multipartPostWithContentType() throws IOException {
+		this.snippets.expectRequestUri().withContents(
+				requestUri(RequestMethod.POST, "/{a}/{b}").header("Content-Type",
+						"multipart/form-data; boundary=" + BOUNDARY));
+
+		new RequestUriSnippet().document(this.operationBuilder
+				.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+						"/{a}/{b}")
+				.request("http://localhost/upload").method("POST")
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.MULTIPART_FORM_DATA_VALUE)
+				.part("image", "<< data >>".getBytes())
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.IMAGE_PNG_VALUE).build());
+	}
+
+	@Test
+	public void requestWithCustomSnippetAttributes() throws IOException {
+		this.snippets.expectRequestUri()
+				.withContents(containsString("Title for the request"));
+		TemplateResourceResolver resolver = mock(TemplateResourceResolver.class);
+		given(resolver.resolveTemplateResource("request-uri"))
+				.willReturn(snippetResource("request-uri-with-title"));
+
+		new RequestUriSnippet(attributes(key("title").value("Title for the request")))
+				.document(this.operationBuilder
+						.attribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE,
+								"/{a}/{b}")
+						.attribute(TemplateEngine.class.getName(),
+								new MustacheTemplateEngine(resolver))
+						.request("http://localhost/foo").build());
+	}
+
+}

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/test/ExpectedSnippets.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/test/ExpectedSnippets.java
@@ -109,6 +109,10 @@ public class ExpectedSnippets extends OperationTestRule {
 		return expect("http-response");
 	}
 
+	public ExpectedSnippet expectRequestUri() {
+		return expect("request-uri");
+	}
+
 	public ExpectedSnippet expectRequestParameters() {
 		return expect("request-parameters");
 	}

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/test/SnippetMatchers.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/test/SnippetMatchers.java
@@ -87,6 +87,16 @@ public final class SnippetMatchers {
 		return new HttpResponseMatcher(status, new MarkdownCodeBlockMatcher<>("http"), 2);
 	}
 
+	public static RequestUriMatcher requestUri(TemplateFormat format,
+			RequestMethod requestMethod, String urlTemplate) {
+		if ("adoc".equals(format.getFileExtension())) {
+			return new RequestUriMatcher(requestMethod, urlTemplate,
+					new AsciidoctorCodeBlockMatcher<>("http", "nowrap"), 3);
+		}
+		return new RequestUriMatcher(requestMethod, urlTemplate,
+				new MarkdownCodeBlockMatcher<>("http"), 2);
+	}
+
 	@SuppressWarnings({ "rawtypes" })
 	public static CodeBlockMatcher<?> codeBlock(TemplateFormat format, String language) {
 		if ("adoc".equals(format.getFileExtension())) {
@@ -291,6 +301,19 @@ public final class SnippetMatchers {
 			super(delegate, headerOffset);
 			this.content(requestMethod.name() + " " + uri + " HTTP/1.1");
 			this.content("");
+		}
+
+	}
+
+	/**
+	 * A {@link Matcher} for an HTTP request.
+	 */
+	public static final class RequestUriMatcher extends HttpMatcher<RequestUriMatcher> {
+
+		private RequestUriMatcher(RequestMethod requestMethod, String uri,
+				CodeBlockMatcher<?> delegate, int headerOffset) {
+			super(delegate, headerOffset);
+			this.content(requestMethod.name() + " " + uri);
 		}
 
 	}

--- a/spring-restdocs-core/src/test/resources/custom-snippet-templates/asciidoctor/request-uri-with-title.snippet
+++ b/spring-restdocs-core/src/test/resources/custom-snippet-templates/asciidoctor/request-uri-with-title.snippet
@@ -1,0 +1,8 @@
+[source,http]
+.{{title}}
+----
+{{method}} {{urlTemplate}}
+{{#headers}}
+{{name}}: {{value}}
+{{/headers}}
+----

--- a/spring-restdocs-core/src/test/resources/custom-snippet-templates/markdown/request-uri-with-title.snippet
+++ b/spring-restdocs-core/src/test/resources/custom-snippet-templates/markdown/request-uri-with-title.snippet
@@ -1,0 +1,7 @@
+{{title}}
+```http
+{{method}} {{urlTemplate}}
+{{#headers}}
+{{name}}: {{value}}
+{{/headers}}
+```

--- a/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcRestDocumentationIntegrationTests.java
+++ b/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcRestDocumentationIntegrationTests.java
@@ -85,6 +85,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.partWith
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.restdocs.request.RequestDocumentation.requestUri;
 import static org.springframework.restdocs.snippet.Attributes.attributes;
 import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.restdocs.templates.TemplateFormats.asciidoctor;
@@ -292,6 +293,19 @@ public class MockMvcRestDocumentationIntegrationTests {
 		assertExpectedSnippetFilesExist(new File("build/generated-snippets/links"),
 				"http-request.adoc", "http-response.adoc", "curl-request.adoc",
 				"links.adoc");
+	}
+
+	@Test
+	public void requestUriSnippet() throws Exception {
+		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.context)
+				.apply(documentationConfiguration(this.restDocumentation)).build();
+
+		mockMvc.perform(get("{foo}", "/").accept(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk()).andDo(document("links", requestUri()));
+
+		assertExpectedSnippetFilesExist(new File("build/generated-snippets/links"),
+				"http-request.adoc", "http-response.adoc", "curl-request.adoc",
+				"request-uri.adoc");
 	}
 
 	@Test

--- a/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/RestAssuredRestDocumentationIntegrationTests.java
+++ b/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/RestAssuredRestDocumentationIntegrationTests.java
@@ -58,6 +58,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.partWith
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.restdocs.request.RequestDocumentation.requestUri;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.templates.TemplateFormats.asciidoctor;
@@ -155,6 +156,17 @@ public class RestAssuredRestDocumentationIntegrationTests {
 		assertExpectedSnippetFilesExist(new File("build/generated-snippets/links"),
 				"http-request.adoc", "http-response.adoc", "curl-request.adoc",
 				"links.adoc");
+	}
+
+	@Test
+	public void requestUriSnippet() throws Exception {
+		given().port(tomcat.getPort())
+				.filter(documentationConfiguration(this.restDocumentation))
+				.filter(document("request-uri", requestUri())).accept("application/json")
+				.get("/{foo}", "").then().statusCode(200);
+		assertExpectedSnippetFilesExist(new File("build/generated-snippets/request-uri"),
+				"http-request.adoc", "http-response.adoc", "curl-request.adoc",
+				"request-uri.adoc");
 	}
 
 	@Test

--- a/spring-restdocs-webtestclient/src/test/java/org/springframework/restdocs/webtestclient/WebTestClientRestDocumentationIntegrationTests.java
+++ b/spring-restdocs-webtestclient/src/test/java/org/springframework/restdocs/webtestclient/WebTestClientRestDocumentationIntegrationTests.java
@@ -54,6 +54,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.partWith
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.restdocs.request.RequestDocumentation.requestUri;
 import static org.springframework.restdocs.templates.TemplateFormats.asciidoctor;
 import static org.springframework.restdocs.test.SnippetMatchers.codeBlock;
 import static org.springframework.restdocs.test.SnippetMatchers.httpResponse;
@@ -108,6 +109,17 @@ public class WebTestClientRestDocumentationIntegrationTests {
 		assertExpectedSnippetFilesExist(outputDir, "http-request.adoc",
 				"http-response.adoc", "curl-request.adoc", "httpie-request.adoc",
 				"request-body.adoc", "response-body.adoc");
+	}
+
+	@Test
+	public void requestUriSnippet() {
+		File outputDir = new File("build/generated-snippets/request-uri");
+		FileSystemUtils.deleteRecursively(outputDir);
+		this.webTestClient.get().uri("/{foo}/{bar}", "1", "2").exchange().expectStatus()
+				.isOk().expectBody().consumeWith(document("request-uri", requestUri()));
+		assertExpectedSnippetFilesExist(outputDir, "http-request.adoc",
+				"http-response.adoc", "curl-request.adoc", "httpie-request.adoc",
+				"request-body.adoc", "response-body.adoc", "request-uri.adoc");
 	}
 
 	@Test


### PR DESCRIPTION
Add RequestUriSnippet, which by default documents the HTTP verb, URI (template), and media type properties of an HTTP request

Fixes gh-299