### PR TITLE
 task name jar does not match boot 2.0

### DIFF
--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -245,7 +245,7 @@ from where it will be included in the jar file.
 [source,indent=0,role="secondary"]
 .Gradle
 ----
-	jar {
+	bootJar {
 		dependsOn asciidoctor <1>
 		from ("${asciidoctor.outputDir}/html5") { <2>
 			into 'static/docs'


### PR DESCRIPTION
The jar Task in build.grade is from 2.0 to bootJar.

Changed to jar -> bootJar.