### PR TITLE
Jojoldu/jar task name fix

### DIFF
--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -245,7 +245,7 @@ from where it will be included in the jar file.
 [source,indent=0,role="secondary"]
 .Gradle
 ----
-	jar {
+	bootJar {
 		dependsOn asciidoctor <1>
 		from ("${asciidoctor.outputDir}/html5") { <2>
 			into 'static/docs'

--- a/samples/junit5/build.gradle
+++ b/samples/junit5/build.gradle
@@ -58,7 +58,7 @@ asciidoctor {
 	dependsOn test
 }
 
-jar {
+bootJar {
 	dependsOn asciidoctor
 	from ("${asciidoctor.outputDir}/html5") {
 		into 'static/docs'

--- a/samples/rest-assured/build.gradle
+++ b/samples/rest-assured/build.gradle
@@ -50,7 +50,7 @@ asciidoctor {
 	dependsOn test
 }
 
-jar {
+bootJar {
 	dependsOn asciidoctor
 	from ("${asciidoctor.outputDir}/html5") {
 		into 'static/docs'

--- a/samples/rest-notes-spring-hateoas/build.gradle
+++ b/samples/rest-notes-spring-hateoas/build.gradle
@@ -56,7 +56,7 @@ asciidoctor {
 	dependsOn test
 }
 
-jar {
+bootJar {
 	dependsOn asciidoctor
 	from ("${asciidoctor.outputDir}/html5") {
 		into 'static/docs'

--- a/samples/testng/build.gradle
+++ b/samples/testng/build.gradle
@@ -55,7 +55,7 @@ asciidoctor {
 	dependsOn test
 }
 
-jar {
+bootJar {
 	dependsOn asciidoctor
 	from ("${asciidoctor.outputDir}/html5") {
 		into 'static/docs'

--- a/samples/web-test-client/build.gradle
+++ b/samples/web-test-client/build.gradle
@@ -41,7 +41,7 @@ asciidoctor {
 	dependsOn test
 }
 
-jar {
+bootJar {
 	dependsOn asciidoctor
 	from ("${asciidoctor.outputDir}/html5") {
 		into 'static/docs'


### PR DESCRIPTION
The jar Task in build.grade is from 2.0 to bootJar.

Changed to jar -> bootJar
