### PR TITLE
Remove FieldDoesNotExistException handling

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonContentHandler.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/JsonContentHandler.java
@@ -84,15 +84,10 @@ class JsonContentHandler implements ContentHandler {
 		if (!this.fieldProcessor.hasField(candidate.getPath(), payload)) {
 			return true;
 		}
-		try {
-			ExtractedField extracted = this.fieldProcessor.extract(candidate.getPath(),
-					payload);
-			return extracted.getValue() instanceof Collection
-					&& ((Collection<?>) extracted.getValue()).isEmpty();
-		}
-		catch (FieldDoesNotExistException ex) {
-			return true;
-		}
+		ExtractedField extracted = this.fieldProcessor.extract(candidate.getPath(),
+				payload);
+		return extracted.getValue() instanceof Collection
+				&& ((Collection<?>) extracted.getValue()).isEmpty();
 	}
 
 	@Override


### PR DESCRIPTION
This PR removes `FieldDoesNotExistException` handling in `JsonContentHandler.isMissing()` as it doesn't seem to be possible to be thrown.