### PR TITLE
Use ID-based equality check for TemplateFormat consistently

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/templates/TemplateFormats.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/templates/TemplateFormats.java
@@ -17,7 +17,7 @@
 package org.springframework.restdocs.templates;
 
 /**
- * An enumeration of the built-in formats for which templates are provuded.
+ * An enumeration of the built-in formats for which templates are provided.
  *
  * @author Andy Wilkinson
  * @since 1.1.0

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/config/RestDocumentationConfigurerTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/config/RestDocumentationConfigurerTests.java
@@ -100,8 +100,8 @@ public class RestDocumentationConfigurerTests {
 		SnippetConfiguration snippetConfiguration = (SnippetConfiguration) configuration
 				.get(SnippetConfiguration.class.getName());
 		assertThat(snippetConfiguration.getEncoding(), is(equalTo("UTF-8")));
-		assertThat(snippetConfiguration.getTemplateFormat(),
-				is(equalTo(TemplateFormats.asciidoctor())));
+		assertThat(snippetConfiguration.getTemplateFormat().getId(),
+				is(equalTo(TemplateFormats.asciidoctor().getId())));
 
 		OperationRequestPreprocessor defaultOperationRequestPreprocessor = (OperationRequestPreprocessor) configuration
 				.get(RestDocumentationGenerator.ATTRIBUTE_NAME_DEFAULT_OPERATION_REQUEST_PREPROCESSOR);
@@ -190,8 +190,8 @@ public class RestDocumentationConfigurerTests {
 				instanceOf(SnippetConfiguration.class)));
 		SnippetConfiguration snippetConfiguration = (SnippetConfiguration) configuration
 				.get(SnippetConfiguration.class.getName());
-		assertThat(snippetConfiguration.getTemplateFormat(),
-				is(equalTo(TemplateFormats.markdown())));
+		assertThat(snippetConfiguration.getTemplateFormat().getId(),
+				is(equalTo(TemplateFormats.markdown().getId())));
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/headers/RequestHeadersSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/headers/RequestHeadersSnippetTests.java
@@ -173,7 +173,7 @@ public class RequestHeadersSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String escapeIfNecessary(String input) {
-		if (this.templateFormat.equals(TemplateFormats.markdown())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.markdown().getId())) {
 			return input;
 		}
 		return input.replace("|", "\\|");

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/headers/ResponseHeadersSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/headers/ResponseHeadersSnippetTests.java
@@ -164,7 +164,7 @@ public class ResponseHeadersSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String escapeIfNecessary(String input) {
-		if (this.templateFormat.equals(TemplateFormats.markdown())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.markdown().getId())) {
 			return input;
 		}
 		return input.replace("|", "\\|");

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/LinksSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/LinksSnippetTests.java
@@ -178,7 +178,7 @@ public class LinksSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String escapeIfNecessary(String input) {
-		if (this.templateFormat.equals(TemplateFormats.markdown())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.markdown().getId())) {
 			return input;
 		}
 		return input.replace("|", "\\|");

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/RequestFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/RequestFieldsSnippetTests.java
@@ -461,7 +461,7 @@ public class RequestFieldsSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String escapeIfNecessary(String input) {
-		if (this.templateFormat.equals(TemplateFormats.markdown())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.markdown().getId())) {
 			return input;
 		}
 		return input.replace("|", "\\|");

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
@@ -472,7 +472,7 @@ public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String escapeIfNecessary(String input) {
-		if (this.templateFormat.equals(TemplateFormats.markdown())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.markdown().getId())) {
 			return input;
 		}
 		return input.replace("|", "\\|");

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/PathParametersSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/PathParametersSnippetTests.java
@@ -87,8 +87,7 @@ public class PathParametersSnippetTests extends AbstractSnippetTests {
 	public void missingOptionalPathParameter() throws IOException {
 		this.snippets.expectPathParameters()
 				.withContents(tableWithTitleAndHeader(
-						this.templateFormat == TemplateFormats.asciidoctor() ? "+/{a}+"
-								: "`/{a}`",
+						getTitle("/{a}"),
 						"Parameter", "Description").row("`a`", "one").row("`b`", "two"));
 		new PathParametersSnippet(Arrays.asList(parameterWithName("a").description("one"),
 				parameterWithName("b").description("two").optional()))
@@ -101,8 +100,7 @@ public class PathParametersSnippetTests extends AbstractSnippetTests {
 	public void presentOptionalPathParameter() throws IOException {
 		this.snippets.expectPathParameters()
 				.withContents(tableWithTitleAndHeader(
-						this.templateFormat == TemplateFormats.asciidoctor() ? "+/{a}+"
-								: "`/{a}`",
+						getTitle("/{a}"),
 						"Parameter", "Description").row("`a`", "one"));
 		new PathParametersSnippet(
 				Arrays.asList(parameterWithName("a").description("one").optional()))

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/PathParametersSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/PathParametersSnippetTests.java
@@ -208,7 +208,7 @@ public class PathParametersSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String escapeIfNecessary(String input) {
-		if (this.templateFormat.equals(TemplateFormats.markdown())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.markdown().getId())) {
 			return input;
 		}
 		return input.replace("|", "\\|");
@@ -219,7 +219,7 @@ public class PathParametersSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String getTitle(String title) {
-		if (this.templateFormat.equals(TemplateFormats.asciidoctor())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.asciidoctor().getId())) {
 			return "+" + title + "+";
 		}
 		return "`" + title + "`";

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestParametersSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestParametersSnippetTests.java
@@ -200,7 +200,7 @@ public class RequestParametersSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String escapeIfNecessary(String input) {
-		if (this.templateFormat.equals(TemplateFormats.markdown())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.markdown().getId())) {
 			return input;
 		}
 		return input.replace("|", "\\|");

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestPartsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestPartsSnippetTests.java
@@ -191,7 +191,7 @@ public class RequestPartsSnippetTests extends AbstractSnippetTests {
 	}
 
 	private String escapeIfNecessary(String input) {
-		if (this.templateFormat.equals(TemplateFormats.markdown())) {
+		if (this.templateFormat.getId().equals(TemplateFormats.markdown().getId())) {
 			return input;
 		}
 		return input.replace("|", "\\|");


### PR DESCRIPTION
There are three ways to check equality for `TemplateFormats` constants:

- `getId().equals()`
- `equals()`
- `==`

As they are constants, `==` will be sufficient. So this PR changes to use `==` for equality check consistently.