### PR TITLE
Remove unused gradleWrapperVersion property from Grails sample

### DIFF
--- a/samples/rest-notes-grails/gradle.properties
+++ b/samples/rest-notes-grails/gradle.properties
@@ -1,2 +1,1 @@
 grailsVersion=3.3.2
-gradleWrapperVersion=4.4


### PR DESCRIPTION
This PR removes an unused `gradleWrapperVersion` property.