### PR TITLE
Correct typo in default output directory

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/ManualRestDocumentation.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/ManualRestDocumentation.java
@@ -37,7 +37,7 @@ public final class ManualRestDocumentation implements RestDocumentationContextPr
 
 	/**
 	 * Creates a new {@code ManualRestDocumentation} instance that will generate snippets
-	 * to &lt;gradle/maven build path&gt;/generated-snippet.
+	 * to &lt;gradle/maven build path&gt;/generated-snippets.
 	 */
 	public ManualRestDocumentation() {
 		this(getDefaultOutputDirectory());


### PR DESCRIPTION
Default output directory is generated-snippets and not generated-snippet.