### PR TITLE
restdocs-openapi renamed to restdocs-api-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ There are several that you can contribute to Spring REST Docs:
 | [restdocs-wiremock][17] | Auto-generate [WireMock][18] stubs as part of documenting your RESTful API |
 | [restdocsext-jersey][19] | Enables Spring REST Docs to be used with [Jersey's test framework][20] |
 | [spring-auto-restdocs][21] | Uses introspection and Javadoc to automatically document request and response parameters |
-| [restdocs-raml][22] | A Spring REST Docs extension that adds RAML support |
-| [restdocs-openapi][23] | A Spring REST Docs extension that adds [OpenAPI 2.0][24] support |
+| [restdocs-api-spec][23] | A Spring REST Docs extension that adds API specification support. It currently supports [OpenAPI 2][24] and [OpenAPI 3][25] |
 
 ## Licence
 
@@ -68,6 +67,6 @@ Spring REST Docs is open source software released under the [Apache 2.0 license]
 [19]: https://github.com/RESTDocsEXT/restdocsext-jersey
 [20]: https://jersey.java.net/documentation/latest/test-framework.html
 [21]: https://github.com/ScaCap/spring-auto-restdocs
-[22]: https://github.com/ePages-de/restdocs-raml
-[23]: https://github.com/ePages-de/restdocs-openapi
+[23]: https://github.com/ePages-de/restdocs-api-spec
 [24]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
+[25]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md


### PR DESCRIPTION
`restdocs-openapi` has been renamed to restdocs-api-spec and will offer support for more API specification formats soon.

`restdocs-raml` is no longer actively maintained and is archived.