### PR TITLE
Modernizing the documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 target
 .idea
 *.iml
+.DS_Store

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -7,6 +7,10 @@ repositories {
 	maven { url 'https://repo.spring.io/snapshot' }
 }
 
+ext {
+	docResourcesVersion = '0.1.0.RELEASE'
+}
+
 dependencies {
 	asciidoctor 'io.spring.asciidoctor:spring-asciidoctor-extensions:0.1.2.RELEASE'
 	testCompile project(':spring-restdocs-mockmvc')
@@ -21,11 +25,45 @@ dependencies {
 
 tasks.findByPath("artifactoryPublish")?.enabled = false
 
+configurations {
+	docs
+}
+
+dependencies {
+	docs "io.spring.docresources:spring-doc-resources:${docResourcesVersion}@zip"
+}
+
+task prepareAsciidocBuild(type: Sync) {
+	dependsOn configurations.docs
+	from {
+		configurations.docs.collect { zipTree(it) }
+	}
+	from 'src/docs/asciidoc/'
+	into "$buildDir/asciidoc"
+}
+
 asciidoctor {
+	dependsOn 'prepareAsciidocBuild'
+	sourceDir "$buildDir/asciidoc"
 	sources {
 		include 'index.adoc'
 	}
+	resources {
+		from(sourceDir) {
+			include 'images/*', 'css/*', 'js/**'
+		}
+	}
+	options doctype: 'book'
 	attributes	'revnumber': project.version,
+	'icons': 'font',
+	docinfo: 'shared',
+	stylesdir: 'css/',
+	stylesheet: 'spring.css',
+	'linkcss': true,
+	sectanchors: true,
+	'source-highlighter=highlight.js',
+	'highlightjsdir=js/highlight',
+	'highlightjs-theme=atom-one-dark-reasonable',
 				'branch-or-tag': project.version.endsWith('SNAPSHOT') ? 'master': "v${project.version}"
 	inputs.files(sourceSets.test.java)
 }

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -1,13 +1,10 @@
 = Spring REST Docs
 Andy Wilkinson
-:doctype: book
-:icons: font
-:source-highlighter: highlightjs
 :toc: left
-:toclevels: 3
+:toclevels: 4
 :sectlinks:
 
-:examples-dir: ../../test/java
+:examples-dir: ../../src/test/java
 :github: https://github.com/spring-projects/spring-restdocs
 :source: {github}/tree/{branch-or-tag}
 :samples: {source}/samples

--- a/samples/junit5/build.gradle
+++ b/samples/junit5/build.gradle
@@ -34,7 +34,7 @@ ext {
 	junitJupiterVersion = '5.0.0'
 }
 
-ext['spring-restdocs.version'] = '2.0.3.BUILD-SNAPSHOT'
+ext['spring-restdocs.version'] = '2.0.4.BUILD-SNAPSHOT'
 
 dependencies {
 	asciidoctor "org.springframework.restdocs:spring-restdocs-asciidoctor:${project.ext['spring-restdocs.version']}"

--- a/samples/rest-assured/build.gradle
+++ b/samples/rest-assured/build.gradle
@@ -31,7 +31,7 @@ ext {
 	snippetsDir = file('build/generated-snippets')
 }
 
-ext['spring-restdocs.version'] = '2.0.3.BUILD-SNAPSHOT'
+ext['spring-restdocs.version'] = '2.0.4.BUILD-SNAPSHOT'
 
 dependencies {
 	compile 'org.springframework.boot:spring-boot-starter-web'

--- a/samples/rest-notes-grails/build.gradle
+++ b/samples/rest-notes-grails/build.gradle
@@ -22,7 +22,7 @@ apply plugin: "idea"
 apply plugin: "org.grails.grails-web"
 
 ext {
-	restDocsVersion = "2.0.3.BUILD-SNAPSHOT"
+	restDocsVersion = "2.0.4.BUILD-SNAPSHOT"
 	snippetsDir = file('src/docs/generated-snippets')
 }
 

--- a/samples/rest-notes-slate/build.gradle
+++ b/samples/rest-notes-slate/build.gradle
@@ -27,7 +27,7 @@ ext {
 	snippetsDir = file('build/generated-snippets')
 }
 
-ext['spring-restdocs.version'] = '2.0.3.BUILD-SNAPSHOT'
+ext['spring-restdocs.version'] = '2.0.4.BUILD-SNAPSHOT'
 
 dependencies {
 	compile 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/samples/rest-notes-spring-data-rest/pom.xml
+++ b/samples/rest-notes-spring-data-rest/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
-		<spring-restdocs.version>2.0.3.BUILD-SNAPSHOT</spring-restdocs.version>
+		<spring-restdocs.version>2.0.4.BUILD-SNAPSHOT</spring-restdocs.version>
 	</properties>
 
 	<dependencies>

--- a/samples/rest-notes-spring-hateoas/build.gradle
+++ b/samples/rest-notes-spring-hateoas/build.gradle
@@ -31,7 +31,7 @@ ext {
 	snippetsDir = file('build/generated-snippets')
 }
 
-ext['spring-restdocs.version'] = '2.0.3.BUILD-SNAPSHOT'
+ext['spring-restdocs.version'] = '2.0.4.BUILD-SNAPSHOT'
 
 dependencies {
 	asciidoctor "org.springframework.restdocs:spring-restdocs-asciidoctor:${project.ext['spring-restdocs.version']}"

--- a/samples/testng/build.gradle
+++ b/samples/testng/build.gradle
@@ -31,7 +31,7 @@ ext {
 	snippetsDir = file('build/generated-snippets')
 }
 
-ext['spring-restdocs.version'] = '2.0.3.BUILD-SNAPSHOT'
+ext['spring-restdocs.version'] = '2.0.4.BUILD-SNAPSHOT'
 
 dependencies {
 	asciidoctor "org.springframework.restdocs:spring-restdocs-asciidoctor:${project.ext['spring-restdocs.version']}"

--- a/samples/web-test-client/build.gradle
+++ b/samples/web-test-client/build.gradle
@@ -20,7 +20,7 @@ ext {
 	snippetsDir = file('build/generated-snippets')
 }
 
-ext['spring-restdocs.version'] = '2.0.3.BUILD-SNAPSHOT'
+ext['spring-restdocs.version'] = '2.0.4.BUILD-SNAPSHOT'
 
 dependencies {
 	compile 'io.projectreactor.ipc:reactor-netty:0.7.1.RELEASE'


### PR DESCRIPTION
Now it pulls from spring-doc-resources to get the stylesheet, JavaScript, and static HTML that the modern look and feel uses, and it applies those items to the reference guide.