### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -42,5 +42,5 @@ with regard to the reporter of an incident.
 This Code of Conduct is adapted from the [Contributor Covenant][1], version 1.3.0, available
 at [contributor-covenant.org/version/1/3/0/][2].
 
-[1]: http://contributor-covenant.org
-[2]: http://contributor-covenant.org/version/1/3/0/
+[1]: https://contributor-covenant.org
+[2]: https://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,4 +61,4 @@ The project can then be imported into Eclipse using `File -> Import…` and then
 
 [1]: CODE_OF_CONDUCT.md
 [2]: https://cla.pivotal.io/sign/spring
-[3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[3]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/docs/src/docs/asciidoc/contributing.adoc
+++ b/docs/src/docs/asciidoc/contributing.adoc
@@ -10,7 +10,7 @@ your contributions.
 [[contributing-questions]]
 === Questions
 
-You can ask questions about Spring REST Docs on http://stackoverflow.com[Stack Overflow]
+You can ask questions about Spring REST Docs on https://stackoverflow.com[Stack Overflow]
 by using the `spring-restdocs` tag. Similarly, we encourage you to help your fellow
 Spring REST Docs users by answering questions.
 

--- a/docs/src/docs/asciidoc/documenting-your-api.adoc
+++ b/docs/src/docs/asciidoc/documenting-your-api.adoc
@@ -1287,11 +1287,11 @@ A number of snippets are produced automatically when you document a request and 
 |Snippet | Description
 
 | `curl-request.adoc`
-| Contains the http://curl.haxx.se[`curl`] command that is equivalent to the `MockMvc`
+| Contains the https://curl.haxx.se[`curl`] command that is equivalent to the `MockMvc`
 call that is being documented.
 
 | `httpie-request.adoc`
-| Contains the http://httpie.org[`HTTPie`] command that is equivalent to the `MockMvc`
+| Contains the https://httpie.org[`HTTPie`] command that is equivalent to the `MockMvc`
 call that is being documented.
 
 | `http-request.adoc`

--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -18,12 +18,12 @@ If you want to jump straight in, a number of sample applications are available:
 | {samples}/rest-notes-spring-data-rest[Spring Data REST]
 | Maven
 | Demonstrates the creation of a getting started guide and an API guide for a service
-  implemented by using http://projects.spring.io/spring-data-rest/[Spring Data REST].
+  implemented by using https://projects.spring.io/spring-data-rest/[Spring Data REST].
 
 | {samples}/rest-notes-spring-hateoas[Spring HATEOAS]
 | Gradle
 | Demonstrates the creation of a getting started guide and an API guide for a service
-  implemented by using http://projects.spring.io/spring-hateoas/[Spring HATEOAS].
+  implemented by using https://projects.spring.io/spring-hateoas/[Spring HATEOAS].
 
 |===
 
@@ -64,7 +64,7 @@ If you want to jump straight in, a number of sample applications are available:
 | {samples}/rest-notes-slate[Slate]
 | Gradle
 | Demonstrates the use of Spring REST Docs with Markdown and
-  http://github.com/tripit/slate[Slate].
+  https://github.com/tripit/slate[Slate].
 
 | {samples}/testng[TestNG]
 | Gradle
@@ -72,7 +72,7 @@ If you want to jump straight in, a number of sample applications are available:
 
 | {samples}/junit5[JUnit 5]
 | Gradle
-| Demonstrates the use of Spring REST Docs with http://junit.org/junit5/[JUnit 5].
+| Demonstrates the use of Spring REST Docs with https://junit.org/junit5/[JUnit 5].
 
 |===
 
@@ -263,7 +263,7 @@ from where it will be included in the jar file.
 Spring REST Docs uses Spring MVC's
 {spring-framework-docs}/testing.html#spring-mvc-test-framework[test framework],
 Spring WebFlux's {spring-framework-docs}/testing.html#webtestclient[`WebTestClient`], or
-http://www.rest-assured.io[REST Assured] to make requests to the service that you are
+http://rest-assured.io/[REST Assured] to make requests to the service that you are
 documenting. It then produces documentation snippets for the request and the resulting
 response.
 
@@ -580,7 +580,7 @@ the resulting HTML files depends on whether you use Maven or Gradle:
 
 You can then include the generated snippets in the manually created Asciidoc file
 (described earlier in this section) by using the
-http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include macro].
+https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include macro].
 You can use the `snippets` attribute that is automatically set by
 `spring-restdocs-asciidoctor` configured in the
 <<getting-started-build-configuration,build configuration>> to reference the snippets

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -12,7 +12,7 @@ Andy Wilkinson; Jay Bryant
 :source: {github}/tree/{branch-or-tag}
 :samples: {source}/samples
 :templates: {source}spring-restdocs/src/main/resources/org/springframework/restdocs/templates
-:spring-boot-docs: http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle
+:spring-boot-docs: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle
 :spring-framework-docs: https://docs.spring.io/spring-framework/docs/5.0.x/spring-framework-reference
 :spring-framework-api: https://docs.spring.io/spring-framework/docs/5.0.x/javadoc-api
 

--- a/docs/src/docs/asciidoc/introduction.adoc
+++ b/docs/src/docs/asciidoc/introduction.adoc
@@ -6,14 +6,14 @@ your RESTful services.
 
 Writing high-quality documentation is difficult. One way to ease that difficulty is to use
 tools that are well-suited to the job. To this end, Spring REST Docs uses
-http://asciidoctor.org[Asciidoctor] by default. Asciidoctor processes plain text and
+https://asciidoctor.org[Asciidoctor] by default. Asciidoctor processes plain text and
 produces HTML, styled and laid out to suit your needs. If you prefer, you can also
 configure Spring REST Docs to use Markdown.
 
 Spring REST Docs uses snippets produced by tests written with Spring MVC's
 {spring-framework-docs}/testing.html#spring-mvc-test-framework[test framework], Spring
 WebFlux's {spring-framework-docs}/testing.html#webtestclient[`WebTestClient`] or
-http://www.rest-assured.io[REST Assured 3]. This test-driven approach helps to guarantee
+http://rest-assured.io/[REST Assured 3]. This test-driven approach helps to guarantee
 the accuracy of your service's documentation. If a snippet is incorrect, the test that
 produces it fails.
 

--- a/docs/src/docs/asciidoc/working-with-asciidoctor.adoc
+++ b/docs/src/docs/asciidoc/working-with-asciidoctor.adoc
@@ -12,8 +12,8 @@ NOTE: Asciidoc is the document format. Asciidoctor is the tool that produces con
 [[working-with-asciidoctor-resources]]
 === Resources
 
- * http://asciidoctor.org/docs/asciidoc-syntax-quick-reference[Syntax quick reference]
- * http://asciidoctor.org/docs/user-manual[User manual]
+ * https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[Syntax quick reference]
+ * https://asciidoctor.org/docs/user-manual[User manual]
 
 
 
@@ -139,7 +139,7 @@ the `curl-request` snippet to be "Example request", you can use the following at
 [[working-with-asciidoctor-including-snippets-individual]]
 ==== Including Individual Snippets
 
-The http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include
+The https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include
 macro] is used to include individual snippets in your documentation. You can use the
 `snippets` attribute (which is automatically set by `spring-restdocs-asciidoctor`
 configured  in the <<getting-started-build-configuration, build configuration>>) to
@@ -167,7 +167,7 @@ snippet is included or by using a custom snippet template.
 ==== Formatting Columns
 
 Asciidoctor has rich support for
-http://asciidoctor.org/docs/user-manual/#cols-format[formatting a table's columns]. As the
+https://asciidoctor.org/docs/user-manual/#cols-format[formatting a table's columns]. As the
 following example shows, you can specify the widths of a table's columns by using the
 `cols` attribute:
 
@@ -222,5 +222,5 @@ in a cell that contains the value of a `description` attribute:
 
 ==== Further Reading
 
-See the http://asciidoctor.org/docs/user-manual/#tables[Tables section of the
+See the https://asciidoctor.org/docs/user-manual/#tables[Tables section of the
 Asciidoctor user manual] for more information about customizing tables.

--- a/samples/rest-notes-grails/README.md
+++ b/samples/rest-notes-grails/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This is a sample project using Grails 3, Spock, and Spring REST docs. For more
-information about the Grails framework please see [grails.org](http://grails.org).
+information about the Grails framework please see [grails.org](https://grails.org).
 
 Grails is built on top of Spring Boot and Gradle so there are a few different ways to
 run this project including:

--- a/samples/rest-notes-grails/grails-app/conf/logback.groovy
+++ b/samples/rest-notes-grails/grails-app/conf/logback.groovy
@@ -17,7 +17,7 @@
 import grails.util.BuildSettings
 import grails.util.Environment
 
-// See http://logback.qos.ch/manual/groovy.html for details on configuration
+// See https://logback.qos.ch/manual/groovy.html for details on configuration
 appender('STDOUT', ConsoleAppender) {
 	encoder(PatternLayoutEncoder) {
 		pattern = "%level %logger - %msg%n"

--- a/samples/rest-notes-slate/README.md
+++ b/samples/rest-notes-slate/README.md
@@ -21,4 +21,4 @@ documentation by [ERB][4]. The combined Markdown document is then turned into HT
 [1]: https://github.com/lord/slate
 [2]: slate/source/api-guide.html.md.erb
 [3]: src/test/java/com/example/notes/ApiDocumentation.java
-[4]: http://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html
+[4]: https://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html

--- a/samples/rest-notes-slate/slate/README.md
+++ b/samples/rest-notes-slate/slate/README.md
@@ -27,7 +27,7 @@ Features
 
 * **Let your users update your documentation for you** — By default, your Slate-generated documentation is hosted in a public Github repository. Not only does this mean you get free hosting for your docs with Github Pages, but it also makes it simple for other developers to make pull requests to your docs if they find typos or other problems. Of course, if you don't want to use GitHub, you're also welcome to host your docs elsewhere.
 
-Getting started with Slate is super easy! Simply fork this repository and follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](http://lord.github.io/slate).
+Getting started with Slate is super easy! Simply fork this repository and follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](https://lord.github.io/slate).
 
 Getting Started with Slate
 ------------------------------
@@ -67,18 +67,18 @@ Companies Using Slate
 
 * [NASA](https://api.nasa.gov)
 * [IBM](https://docs.cloudant.com/api.html)
-* [Sony](http://developers.cimediacloud.com)
-* [Mozilla](http://localforage.github.io/localForage/)
+* [Sony](https://developers.cimediacloud.com)
+* [Mozilla](https://localforage.github.io/localForage/)
 * [Best Buy](https://bestbuyapis.github.io/api-documentation/)
 * [Travis-CI](https://docs.travis-ci.com/api/)
 * [Greenhouse](https://developers.greenhouse.io/harvest.html)
-* [Woocommerce](http://woocommerce.github.io/woocommerce-rest-api-docs/)
-* [Appium](http://appium.io/slate/en/master)
+* [Woocommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/)
+* [Appium](https://appium.io/slate/en/master)
 * [Dwolla](https://docs.dwolla.com/)
 * [Clearbit](https://clearbit.com/docs)
 * [Coinbase](https://developers.coinbase.com/api)
-* [Parrot Drones](http://developer.parrot.com/docs/bebop/)
-* [Fidor Bank](http://docs.fidor.de/)
+* [Parrot Drones](https://developer.parrot.com/docs/bebop/)
+* [Fidor Bank](https://docs.fidor.de/)
 * [Scale](https://docs.scaleapi.com/)
 
 You can view more in [the list on the wiki](https://github.com/lord/slate/wiki/Slate-in-the-Wild).
@@ -100,7 +100,7 @@ Thanks to the following people who have submitted major pull requests:
 - [@realityking](https://github.com/realityking)
 - [@cvkef](https://github.com/cvkef)
 
-Also, thanks to [Sauce Labs](http://saucelabs.com) for helping sponsor the project.
+Also, thanks to [Sauce Labs](https://saucelabs.com) for helping sponsor the project.
 
 Special Thanks
 --------------------
@@ -108,4 +108,4 @@ Special Thanks
 - [jquery.tocify.js](https://github.com/gfranko/jquery.tocify.js)
 - [middleman-syntax](https://github.com/middleman/middleman-syntax)
 - [middleman-gh-pages](https://github.com/edgecase/middleman-gh-pages)
-- [Font Awesome](http://fortawesome.github.io/Font-Awesome/)
+- [Font Awesome](https://fortawesome.github.io/Font-Awesome/)

--- a/samples/rest-notes-slate/slate/source/index.html.md
+++ b/samples/rest-notes-slate/slate/source/index.html.md
@@ -55,7 +55,7 @@ let api = kittn.authorize('meowmeowmeow');
 
 > Make sure to replace `meowmeowmeow` with your API key.
 
-Kittn uses API keys to allow access to the API. You can register a new Kittn API key at our [developer portal](http://example.com/developers).
+Kittn uses API keys to allow access to the API. You can register a new Kittn API key at our [developer portal](https://example.com/developers).
 
 Kittn expects for the API key to be included in all API requests to the server in a header that looks like the following:
 
@@ -84,7 +84,7 @@ api.kittens.get()
 ```
 
 ```shell
-curl "http://example.com/api/kittens"
+curl "https://example.com/api/kittens"
   -H "Authorization: meowmeowmeow"
 ```
 
@@ -120,7 +120,7 @@ This endpoint retrieves all kittens.
 
 ### HTTP Request
 
-`GET http://example.com/api/kittens`
+`GET https://example.com/api/kittens`
 
 ### Query Parameters
 
@@ -150,7 +150,7 @@ api.kittens.get(2)
 ```
 
 ```shell
-curl "http://example.com/api/kittens/2"
+curl "https://example.com/api/kittens/2"
   -H "Authorization: meowmeowmeow"
 ```
 
@@ -179,7 +179,7 @@ This endpoint retrieves a specific kitten.
 
 ### HTTP Request
 
-`GET http://example.com/kittens/<ID>`
+`GET https://example.com/kittens/<ID>`
 
 ### URL Parameters
 

--- a/samples/rest-notes-slate/slate/source/javascripts/app/_lang.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/app/_lang.js
@@ -65,7 +65,7 @@ under the License.
 
       key = decodeURIComponent(key);
       // missing `=` should be `null`:
-      // http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
+      // https://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
       val = val === undefined ? null : decodeURIComponent(val);
 
       if (!ret.hasOwnProperty(key)) {

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_energize.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_energize.js
@@ -115,7 +115,7 @@
 
     /** 
      * Special logic for standalone web apps
-     * See http://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window
+     * See https://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window
      */
     if(standAlone) {
       window.location = target.getAttribute("href");

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.highlight.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.highlight.js
@@ -2,7 +2,7 @@
  * jQuery Highlight plugin
  *
  * Based on highlight v3 by Johann Burkard
- * http://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html
+ * https://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html
  *
  * Code a little bit refactored and cleaned (in my humble opinion).
  * Most important changes:

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.js
@@ -1,13 +1,13 @@
 /*!
  * jQuery JavaScript Library v2.2.0
- * http://jquery.com/
+ * https://jquery.com/
  *
  * Includes Sizzle.js
- * http://sizzlejs.com/
+ * https://sizzlejs.com/
  *
  * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
- * http://jquery.org/license
+ * https://jquery.org/license
  *
  * Date: 2016-01-08T20:02Z
  */
@@ -540,11 +540,11 @@ function isArrayLike( obj ) {
 var Sizzle =
 /*!
  * Sizzle CSS Selector Engine v2.2.1
- * http://sizzlejs.com/
+ * https://sizzlejs.com/
  *
  * Copyright jQuery Foundation and other contributors
  * Released under the MIT license
- * http://jquery.org/license
+ * https://jquery.org/license
  *
  * Date: 2015-10-17
  */
@@ -598,7 +598,7 @@ var i,
   push = arr.push,
   slice = arr.slice,
   // Use a stripped-down indexOf as it's faster than native
-  // http://jsperf.com/thor-indexof-vs-for/5
+  // https://jsperf.com/thor-indexof-vs-for/5
   indexOf = function( list, elem ) {
     var i = 0,
       len = list.length;
@@ -614,13 +614,13 @@ var i,
 
   // Regular expressions
 
-  // http://www.w3.org/TR/css3-selectors/#whitespace
+  // https://www.w3.org/TR/css3-selectors/#whitespace
   whitespace = "[\\x20\\t\\r\\n\\f]",
 
-  // http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
+  // https://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
   identifier = "(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",
 
-  // Attribute selectors: http://www.w3.org/TR/selectors/#attribute-selectors
+  // Attribute selectors: https://www.w3.org/TR/selectors/#attribute-selectors
   attributes = "\\[" + whitespace + "*(" + identifier + ")(?:" + whitespace +
     // Operator (capture 2)
     "*([*^$|!~]?=)" + whitespace +
@@ -677,7 +677,7 @@ var i,
   rsibling = /[+~]/,
   rescape = /'|\\/g,
 
-  // CSS escapes http://www.w3.org/TR/CSS21/syndata.html#escaped-characters
+  // CSS escapes https://www.w3.org/TR/CSS21/syndata.html#escaped-characters
   runescape = new RegExp( "\\\\([\\da-f]{1,6}" + whitespace + "?|(" + whitespace + ")|.)", "ig" ),
   funescape = function( _, escaped, escapedWhitespace ) {
     var high = "0x" + escaped - 0x10000;
@@ -1169,7 +1169,7 @@ setDocument = Sizzle.setDocument = function( node ) {
   // We allow this because of a bug in IE8/9 that throws an error
   // whenever `document.activeElement` is accessed on an iframe
   // So, we allow :focus to pass through QSA all the time to avoid the IE error
-  // See http://bugs.jquery.com/ticket/13378
+  // See https://bugs.jquery.com/ticket/13378
   rbuggyQSA = [];
 
   if ( (support.qsa = rnative.test( document.querySelectorAll )) ) {
@@ -1180,7 +1180,7 @@ setDocument = Sizzle.setDocument = function( node ) {
       // This is to test IE's treatment of not explicitly
       // setting a boolean content attribute,
       // since its presence should be enough
-      // http://bugs.jquery.com/ticket/12359
+      // https://bugs.jquery.com/ticket/12359
       docElem.appendChild( div ).innerHTML = "<a id='" + expando + "'></a>" +
         "<select id='" + expando + "-\r\\' msallowcapture=''>" +
         "<option selected=''></option></select>";
@@ -1188,7 +1188,7 @@ setDocument = Sizzle.setDocument = function( node ) {
       // Support: IE8, Opera 11-12.16
       // Nothing should be selected when empty strings follow ^= or $= or *=
       // The test attribute must be unknown in Opera but "safe" for WinRT
-      // http://msdn.microsoft.com/en-us/library/ie/hh465388.aspx#attribute_section
+      // https://msdn.microsoft.com/en-us/library/ie/hh465388.aspx#attribute_section
       if ( div.querySelectorAll("[msallowcapture^='']").length ) {
         rbuggyQSA.push( "[*^$]=" + whitespace + "*(?:''|\"\")" );
       }
@@ -1205,7 +1205,7 @@ setDocument = Sizzle.setDocument = function( node ) {
       }
 
       // Webkit/Opera - :checked should return selected option elements
-      // http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
+      // https://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
       // IE8 throws error here and will not see later tests
       if ( !div.querySelectorAll(":checked").length ) {
         rbuggyQSA.push(":checked");
@@ -1802,7 +1802,7 @@ Expr = Sizzle.selectors = {
 
     "PSEUDO": function( pseudo, argument ) {
       // pseudo-class names are case-insensitive
-      // http://www.w3.org/TR/selectors/#pseudo-classes
+      // https://www.w3.org/TR/selectors/#pseudo-classes
       // Prioritize by case sensitivity in case custom pseudos are added with uppercase letters
       // Remember that setFilters inherits from pseudos
       var args,
@@ -1889,7 +1889,7 @@ Expr = Sizzle.selectors = {
     // or beginning with the identifier C immediately followed by "-".
     // The matching of C against the element's language value is performed case-insensitively.
     // The identifier C does not have to be a valid language name."
-    // http://www.w3.org/TR/selectors/#lang-pseudo
+    // https://www.w3.org/TR/selectors/#lang-pseudo
     "lang": markFunction( function( lang ) {
       // lang value must be a valid identifier
       if ( !ridentifier.test(lang || "") ) {
@@ -1936,7 +1936,7 @@ Expr = Sizzle.selectors = {
 
     "checked": function( elem ) {
       // In CSS3, :checked should return both checked and selected elements
-      // http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
+      // https://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
       var nodeName = elem.nodeName.toLowerCase();
       return (nodeName === "input" && !!elem.checked) || (nodeName === "option" && !!elem.selected);
     },
@@ -1953,7 +1953,7 @@ Expr = Sizzle.selectors = {
 
     // Contents
     "empty": function( elem ) {
-      // http://www.w3.org/TR/selectors/#empty-pseudo
+      // https://www.w3.org/TR/selectors/#empty-pseudo
       // :empty is negated by element (1) or content nodes (text: 3; cdata: 4; entity ref: 5),
       //   but not by others (comment: 8; processing instruction: 7; etc.)
       // nodeType < 6 works because attributes (2) do not appear as children
@@ -2627,7 +2627,7 @@ support.sortDetached = assert(function( div1 ) {
 
 // Support: IE<8
 // Prevent attribute/property "interpolation"
-// http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
+// https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
 if ( !assert(function( div ) {
   div.innerHTML = "<a href='#'></a>";
   return div.firstChild.getAttribute("href") === "#" ;
@@ -4995,7 +4995,7 @@ jQuery.Event = function( src, props ) {
 };
 
 // jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
-// http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
+// https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
 jQuery.Event.prototype = {
   constructor: jQuery.Event,
   isDefaultPrevented: returnFalse,
@@ -5328,7 +5328,7 @@ jQuery.extend( {
     if ( !support.noCloneChecked && ( elem.nodeType === 1 || elem.nodeType === 11 ) &&
         !jQuery.isXMLDoc( elem ) ) {
 
-      // We eschew Sizzle here for performance reasons: http://jsperf.com/getall-vs-sizzle/2
+      // We eschew Sizzle here for performance reasons: https://jsperf.com/getall-vs-sizzle/2
       destElements = getAll( clone );
       srcElements = getAll( elem );
 
@@ -5805,7 +5805,7 @@ function curCSS( elem, name, computed ) {
     // Android Browser returns percentage for some values,
     // but width seems to be reliably pixels.
     // This is against the CSSOM draft spec:
-    // http://dev.w3.org/csswg/cssom/#resolved-values
+    // https://dev.w3.org/csswg/cssom/#resolved-values
     if ( !support.pixelMarginRight() && rnumnonpx.test( ret ) && rmargin.test( name ) ) {
 
       // Remember the original values
@@ -7069,7 +7069,7 @@ jQuery.fx.speeds = {
 
 
 // Based off of the plugin by Clint Helfers, with permission.
-// http://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/
+// https://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/
 jQuery.fn.delay = function( time, type ) {
   time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
   type = type || "fx";
@@ -7302,7 +7302,7 @@ jQuery.extend( {
 
         // elem.tabIndex doesn't always return the
         // correct value when it hasn't been explicitly set
-        // http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
+        // https://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/
         // Use proper attribute retrieval(#12072)
         var tabindex = jQuery.find.attr( elem, "tabindex" );
 
@@ -7912,7 +7912,7 @@ support.focusin = "onfocusin" in window;
 //
 // Support: Chrome, Safari
 // focus(in | out) events fire after focus & blur events,
-// which is spec violation - http://www.w3.org/TR/DOM-Level-3-Events/#events-focusevent-event-order
+// which is spec violation - https://www.w3.org/TR/DOM-Level-3-Events/#events-focusevent-event-order
 // Related ticket - https://code.google.com/p/chromium/issues/detail?id=449857
 if ( !support.focusin ) {
   jQuery.each( { focus: "focusin", blur: "focusout" }, function( orig, fix ) {

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.tocify.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.tocify.js
@@ -1,5 +1,5 @@
 /* jquery Tocify - v1.8.0 - 2013-09-16
-* http://www.gregfranko.com/jquery.tocify.js/
+* http://gregfranko.com/jquery.tocify.js/
 * Copyright (c) 2013 Greg Franko; Licensed MIT
 * Modified lightly by Robert Lord to fix a bug I found,
 * and also so it adds ids to headers
@@ -10,7 +10,7 @@
 // Immediately-Invoked Function Expression (IIFE) [Ben Alman Blog Post](http://benalman.com/news/2010/11/immediately-invoked-function-expression/) that calls another IIFE that contains all of the plugin logic.  I used this pattern so that anyone viewing this code would not have to scroll to the bottom of the page to view the local parameters that were passed to the main IIFE.
 (function(tocify) {
 
-    // ECMAScript 5 Strict Mode: [John Resig Blog Post](http://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/)
+    // ECMAScript 5 Strict Mode: [John Resig Blog Post](https://johnresig.com/blog/ecmascript-5-strict-mode-json-and-more/)
     "use strict";
 
     // Calls the second IIFE and locally passes in the global jQuery, window, and document objects
@@ -21,7 +21,7 @@
 // Locally passes in `jQuery`, the `window` object, the `document` object, and an `undefined` variable.  The `jQuery`, `window` and `document` objects are passed in locally, to improve performance, since javascript first searches for a variable match within the local variables set before searching the global variables set.  All of the global variables are also passed in locally to be minifier friendly. `undefined` can be passed in locally, because it is not a reserved word in JavaScript.
 (function($, window, document, undefined) {
 
-    // ECMAScript 5 Strict Mode: [John Resig Blog Post](http://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/)
+    // ECMAScript 5 Strict Mode: [John Resig Blog Post](https://johnresig.com/blog/ecmascript-5-strict-mode-json-and-more/)
     "use strict";
 
     var tocClassName = "tocify",

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery_ui.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery_ui.js
@@ -1,5 +1,5 @@
 /*! jQuery UI - v1.11.3 - 2015-02-12
- * http://jqueryui.com
+ * https://jqueryui.com
  * Includes: widget.js
  * Copyright 2015 jQuery Foundation and other contributors; Licensed MIT */
 
@@ -16,13 +16,13 @@
 }(function( $ ) {
   /*!
    * jQuery UI Widget 1.11.3
-   * http://jqueryui.com
+   * https://jqueryui.com
    *
    * Copyright jQuery Foundation and other contributors
    * Released under the MIT license.
-   * http://jquery.org/license
+   * https://jquery.org/license
    *
-   * http://api.jqueryui.com/jQuery.widget/
+   * https://api.jqueryui.com/jQuery.widget/
    */
 
 
@@ -41,7 +41,7 @@
             $( elem ).triggerHandler( "remove" );
           }
 
-          // http://bugs.jquery.com/ticket/8235
+          // https://bugs.jquery.com/ticket/8235
         } catch ( e ) {}
       }
       orig( elems );
@@ -305,7 +305,7 @@
           .unbind( this.eventNamespace )
           .removeData( this.widgetFullName )
         // support: jquery <1.6.3
-        // http://bugs.jquery.com/ticket/9413
+        // https://bugs.jquery.com/ticket/9413
           .removeData( $.camelCase( this.widgetFullName ) );
       this.widget()
           .unbind( this.eventNamespace )

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_lunr.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_lunr.js
@@ -1,5 +1,5 @@
 /**
- * lunr - http://lunrjs.com - A bit like Solr, but much smaller and not as bright - 0.5.7
+ * lunr - https://lunrjs.com - A bit like Solr, but much smaller and not as bright - 0.5.7
  * Copyright (C) 2014 Oliver Nightingale
  * MIT Licensed
  * @license
@@ -1298,12 +1298,12 @@
   /*!
    * lunr.stemmer
    * Copyright (C) 2014 Oliver Nightingale
-   * Includes code from - http://tartarus.org/~martin/PorterStemmer/js.txt
+   * Includes code from - https://tartarus.org/~martin/PorterStemmer/js.txt
    */
 
   /**
    * lunr.stemmer is an english language stemmer, this is a JavaScript
-   * implementation of the PorterStemmer taken from http://tartaurs.org/~martin
+   * implementation of the PorterStemmer taken from https://tartaurs.org/~martin
    *
    * @module
    * @param {String} str The string to stem
@@ -1689,7 +1689,7 @@
   /*!
    * lunr.stemmer
    * Copyright (C) 2014 Oliver Nightingale
-   * Includes code from - http://tartarus.org/~martin/PorterStemmer/js.txt
+   * Includes code from - https://tartarus.org/~martin/PorterStemmer/js.txt
    */
 
   /**

--- a/samples/rest-notes-slate/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-slate/src/test/java/com/example/notes/ApiDocumentation.java
@@ -126,7 +126,7 @@ public class ApiDocumentation {
 		this.noteRepository.deleteAll();
 
 		createNote("REST maturity model",
-				"http://martinfowler.com/articles/richardsonMaturityModel.html");
+				"https://martinfowler.com/articles/richardsonMaturityModel.html");
 		createNote("Hypertext Application Language (HAL)",
 				"http://stateless.co/hal_specification.html");
 		createNote("Application-Level Profile Semantics (ALPS)", "http://alps.io/spec/");
@@ -153,7 +153,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		this.mockMvc.perform(
@@ -181,7 +181,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		String noteLocation = this.mockMvc
@@ -243,7 +243,7 @@ public class ApiDocumentation {
 	public void noteUpdateExample() throws Exception {
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 
 		String noteLocation = this.mockMvc
 				.perform(

--- a/samples/rest-notes-spring-data-rest/src/main/asciidoc/getting-started-guide.adoc
+++ b/samples/rest-notes-spring-data-rest/src/main/asciidoc/getting-started-guide.adoc
@@ -20,7 +20,7 @@ to describe the relationships between resources and to allow navigation between 
 
 [getting-started-running-the-service]
 == Running the service
-RESTful Notes is written using http://projects.spring.io/spring-boot[Spring Boot] which
+RESTful Notes is written using https://projects.spring.io/spring-boot[Spring Boot] which
 makes it easy to get it up and running so that you can start exploring the REST API.
 
 The first step is to clone the Git repository:

--- a/samples/rest-notes-spring-data-rest/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-spring-data-rest/src/test/java/com/example/notes/ApiDocumentation.java
@@ -124,7 +124,7 @@ public class ApiDocumentation {
 		this.noteRepository.deleteAll();
 
 		createNote("REST maturity model",
-				"http://martinfowler.com/articles/richardsonMaturityModel.html");
+				"https://martinfowler.com/articles/richardsonMaturityModel.html");
 		createNote("Hypertext Application Language (HAL)",
 				"http://stateless.co/hal_specification.html");
 		createNote("Application-Level Profile Semantics (ALPS)", "http://alps.io/spec/");
@@ -154,7 +154,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		this.mockMvc.perform(
@@ -182,7 +182,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		String noteLocation = this.mockMvc
@@ -248,7 +248,7 @@ public class ApiDocumentation {
 	public void noteUpdateExample() throws Exception {
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 
 		String noteLocation = this.mockMvc
 				.perform(

--- a/samples/rest-notes-spring-hateoas/src/docs/asciidoc/getting-started-guide.adoc
+++ b/samples/rest-notes-spring-hateoas/src/docs/asciidoc/getting-started-guide.adoc
@@ -20,7 +20,7 @@ to describe the relationships between resources and to allow navigation between 
 
 [getting-started-running-the-service]
 == Running the service
-RESTful Notes is written using http://projects.spring.io/spring-boot[Spring Boot] which
+RESTful Notes is written using https://projects.spring.io/spring-boot[Spring Boot] which
 makes it easy to get it up and running so that you can start exploring the REST API.
 
 The first step is to clone the Git repository:

--- a/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java
@@ -146,7 +146,7 @@ public class ApiDocumentation {
 	public void notesListExample() throws Exception {
 		this.noteRepository.deleteAll();
 
-		createNote("REST maturity model", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		createNote("REST maturity model", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		createNote("Hypertext Application Language (HAL)", "http://stateless.co/hal_specification.html");
 		createNote("Application-Level Profile Semantics (ALPS)", "http://alps.io/spec/");
 
@@ -172,7 +172,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		ConstrainedFields fields = new ConstrainedFields(NoteInput.class);
@@ -204,7 +204,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		String noteLocation = this.mockMvc
@@ -270,7 +270,7 @@ public class ApiDocumentation {
 	public void noteUpdateExample() throws Exception {
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 
 		String noteLocation = this.mockMvc
 			.perform(post("/notes")

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HypermediaDocumentation.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HypermediaDocumentation.java
@@ -423,7 +423,7 @@ public abstract class HypermediaDocumentation {
 	 * {
 	 *     "_links": {
 	 *         "self": {
-	 *             "href": "http://example.com/foo"
+	 *             "href": "https://example.com/foo"
 	 *         }
 	 *     }
 	 * }
@@ -443,7 +443,7 @@ public abstract class HypermediaDocumentation {
 	 *     "links": [
 	 *         {
 	 *             "rel": "self",
-	 *             "href": "http://example.com/foo"
+	 *             "href": "https://example.com/foo"
 	 *         }
 	 *     ]
 	 * }

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/PrettyPrintingContentModifier.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/PrettyPrintingContentModifier.java
@@ -82,7 +82,7 @@ public class PrettyPrintingContentModifier implements ContentModifier {
 		public byte[] prettyPrint(byte[] original) throws Exception {
 			Transformer transformer = TransformerFactory.newInstance().newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount",
+			transformer.setOutputProperty("{https://xml.apache.org/xslt}indent-amount",
 					"4");
 			transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "yes");
 			ByteArrayOutputStream transformed = new ByteArrayOutputStream();

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsPayloadTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsPayloadTests.java
@@ -68,7 +68,7 @@ public class LinkExtractorsPayloadTests {
 	public void singleLink() throws IOException {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("single-link"));
-		assertLinks(Arrays.asList(new Link("alpha", "http://alpha.example.com", "Alpha")),
+		assertLinks(Arrays.asList(new Link("alpha", "https://alpha.example.com", "Alpha")),
 				links);
 	}
 
@@ -76,8 +76,8 @@ public class LinkExtractorsPayloadTests {
 	public void multipleLinksWithDifferentRels() throws IOException {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("multiple-links-different-rels"));
-		assertLinks(Arrays.asList(new Link("alpha", "http://alpha.example.com", "Alpha"),
-				new Link("bravo", "http://bravo.example.com")), links);
+		assertLinks(Arrays.asList(new Link("alpha", "https://alpha.example.com", "Alpha"),
+				new Link("bravo", "https://bravo.example.com")), links);
 	}
 
 	@Test
@@ -85,8 +85,8 @@ public class LinkExtractorsPayloadTests {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("multiple-links-same-rels"));
 		assertLinks(Arrays.asList(
-				new Link("alpha", "http://alpha.example.com/one", "Alpha one"),
-				new Link("alpha", "http://alpha.example.com/two")), links);
+				new Link("alpha", "https://alpha.example.com/one", "Alpha one"),
+				new Link("alpha", "https://alpha.example.com/two")), links);
 	}
 
 	@Test

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessorTests.java
@@ -62,9 +62,9 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriHostCanBeModified() {
 		this.preprocessor.host("api.example.com");
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.foo.com:12345"));
+				.preprocess(createRequestWithUri("https://api.foo.com:12345"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com:12345"));
+				.isEqualTo(URI.create("https://api.example.com:12345"));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST))
 				.isEqualTo("api.example.com:12345");
 	}
@@ -73,9 +73,9 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPortCanBeModified() {
 		this.preprocessor.port(23456);
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com:23456"));
+				.isEqualTo(URI.create("https://api.example.com:23456"));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST))
 				.isEqualTo("api.example.com:23456");
 	}
@@ -84,8 +84,8 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPortCanBeRemoved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345"));
-		assertThat(processed.getUri()).isEqualTo(URI.create("http://api.example.com"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345"));
+		assertThat(processed.getUri()).isEqualTo(URI.create("https://api.example.com"));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST))
 				.isEqualTo("api.example.com");
 	}
@@ -94,27 +94,27 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPathIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345/foo/bar"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345/foo/bar"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com/foo/bar"));
+				.isEqualTo(URI.create("https://api.example.com/foo/bar"));
 	}
 
 	@Test
 	public void requestUriQueryIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345?foo=bar"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345?foo=bar"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com?foo=bar"));
+				.isEqualTo(URI.create("https://api.example.com?foo=bar"));
 	}
 
 	@Test
 	public void requestUriAnchorIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345#foo"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345#foo"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com#foo"));
+				.isEqualTo(URI.create("https://api.example.com#foo"));
 	}
 
 	@Test
@@ -134,7 +134,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createRequestWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getContent()))
-				.isEqualTo("The uri 'http://api.example.com:12345' should be used");
+				.isEqualTo("The uri 'https://api.example.com:12345' should be used");
 	}
 
 	@Test
@@ -214,7 +214,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createResponseWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getContent()))
-				.isEqualTo("The uri 'http://api.example.com:12345' should be used");
+				.isEqualTo("The uri 'https://api.example.com:12345' should be used");
 	}
 
 	@Test
@@ -280,26 +280,26 @@ public class UriModifyingOperationPreprocessorTests {
 	@Test
 	public void urisInRequestHeadersCanBeModified() {
 		OperationRequest processed = this.preprocessor.host("api.example.com")
-				.preprocess(createRequestWithHeader("Foo", "http://locahost:12345"));
+				.preprocess(createRequestWithHeader("Foo", "https://locahost:12345"));
 		assertThat(processed.getHeaders().getFirst("Foo"))
-				.isEqualTo("http://api.example.com:12345");
+				.isEqualTo("https://api.example.com:12345");
 		assertThat(processed.getHeaders().getFirst("Host")).isEqualTo("api.example.com");
 	}
 
 	@Test
 	public void urisInResponseHeadersCanBeModified() {
 		OperationResponse processed = this.preprocessor.host("api.example.com")
-				.preprocess(createResponseWithHeader("Foo", "http://locahost:12345"));
+				.preprocess(createResponseWithHeader("Foo", "https://locahost:12345"));
 		assertThat(processed.getHeaders().getFirst("Foo"))
-				.isEqualTo("http://api.example.com:12345");
+				.isEqualTo("https://api.example.com:12345");
 	}
 
 	@Test
 	public void urisInRequestPartHeadersCanBeModified() {
 		OperationRequest processed = this.preprocessor.host("api.example.com").preprocess(
-				createRequestWithPartWithHeader("Foo", "http://locahost:12345"));
+				createRequestWithPartWithHeader("Foo", "https://locahost:12345"));
 		assertThat(processed.getParts().iterator().next().getHeaders().getFirst("Foo"))
-				.isEqualTo("http://api.example.com:12345");
+				.isEqualTo("https://api.example.com:12345");
 	}
 
 	@Test
@@ -308,7 +308,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createRequestWithPartWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getParts().iterator().next().getContent()))
-				.isEqualTo("The uri 'http://api.example.com:12345' should be used");
+				.isEqualTo("The uri 'https://api.example.com:12345' should be used");
 	}
 
 	@Test

--- a/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-embedded-and-links.json
+++ b/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-embedded-and-links.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
-		"alpha": "http://alpha.example.com",
-		"bravo": "http://bravo.example.com"
+		"alpha": "https://alpha.example.com",
+		"bravo": "https://bravo.example.com"
 	},
 	"_embedded": "embedded-test",
 	"beta": "beta-value",

--- a/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-links.json
+++ b/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-links.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
-		"alpha": "http://alpha.example.com",
-		"bravo": "http://bravo.example.com"
+		"alpha": "https://alpha.example.com",
+		"bravo": "https://bravo.example.com"
 	},
 	"beta": "beta-value",
 	"charlie": "charlie-value"

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-different-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-different-rels.json
@@ -1,10 +1,10 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com",
+		"href": "https://alpha.example.com",
 		"title": "Alpha"
 	}, {
 		"rel": "bravo",
-		"href": "http://bravo.example.com"
+		"href": "https://bravo.example.com"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-same-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-same-rels.json
@@ -1,10 +1,10 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/one",
+		"href": "https://alpha.example.com/one",
 		"title": "Alpha one"
 	}, {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/two"
+		"href": "https://alpha.example.com/two"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/single-link.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/single-link.json
@@ -1,7 +1,7 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com",
+		"href": "https://alpha.example.com",
 		"title": "Alpha"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/wrong-format.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/wrong-format.json
@@ -1,9 +1,9 @@
 {
 	"links": {
 		"alpha": [{
-		    "href": "http://alpha.example.com/one"
+		    "href": "https://alpha.example.com/one"
 		}, {
-		    "href": "http://alpha.example.com/two"
+		    "href": "https://alpha.example.com/two"
 		}]
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-different-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-different-rels.json
@@ -1,11 +1,11 @@
 {
 	"_links": {
 		"alpha": {
-			"href": "http://alpha.example.com",
+			"href": "https://alpha.example.com",
 			"title": "Alpha"
 		},
 		"bravo": {
-			"href": "http://bravo.example.com"
+			"href": "https://bravo.example.com"
 		}
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-same-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-same-rels.json
@@ -1,10 +1,10 @@
 {
 	"_links": {
 		"alpha": [{
-		    "href": "http://alpha.example.com/one",
+		    "href": "https://alpha.example.com/one",
 			"title": "Alpha one"
 		}, {
-		    "href": "http://alpha.example.com/two"
+		    "href": "https://alpha.example.com/two"
 		}]
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/single-link.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/single-link.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
 		"alpha": {
-		    "href": "http://alpha.example.com",
+		    "href": "https://alpha.example.com",
 			"title": "Alpha"
 		}
 	}

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/wrong-format.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/wrong-format.json
@@ -1,9 +1,9 @@
 {
 	"_links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/one"
+		"href": "https://alpha.example.com/one"
 	}, {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/two"
+		"href": "https://alpha.example.com/two"
 	} ]
 }

--- a/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/operation/preprocess/UriModifyingOperationPreprocessorTests.java
+++ b/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured3/operation/preprocess/UriModifyingOperationPreprocessorTests.java
@@ -63,9 +63,9 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriHostCanBeModified() {
 		this.preprocessor.host("api.example.com");
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.foo.com:12345"));
+				.preprocess(createRequestWithUri("https://api.foo.com:12345"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com:12345"));
+				.isEqualTo(URI.create("https://api.example.com:12345"));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST))
 				.isEqualTo("api.example.com:12345");
 	}
@@ -74,9 +74,9 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPortCanBeModified() {
 		this.preprocessor.port(23456);
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com:23456"));
+				.isEqualTo(URI.create("https://api.example.com:23456"));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST))
 				.isEqualTo("api.example.com:23456");
 	}
@@ -85,8 +85,8 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPortCanBeRemoved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345"));
-		assertThat(processed.getUri()).isEqualTo(URI.create("http://api.example.com"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345"));
+		assertThat(processed.getUri()).isEqualTo(URI.create("https://api.example.com"));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST))
 				.isEqualTo("api.example.com");
 	}
@@ -95,27 +95,27 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPathIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345/foo/bar"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345/foo/bar"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com/foo/bar"));
+				.isEqualTo(URI.create("https://api.example.com/foo/bar"));
 	}
 
 	@Test
 	public void requestUriQueryIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345?foo=bar"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345?foo=bar"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com?foo=bar"));
+				.isEqualTo(URI.create("https://api.example.com?foo=bar"));
 	}
 
 	@Test
 	public void requestUriAnchorIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345#foo"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345#foo"));
 		assertThat(processed.getUri())
-				.isEqualTo(URI.create("http://api.example.com#foo"));
+				.isEqualTo(URI.create("https://api.example.com#foo"));
 	}
 
 	@Test
@@ -135,7 +135,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createRequestWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getContent()))
-				.isEqualTo("The uri 'http://api.example.com:12345' should be used");
+				.isEqualTo("The uri 'https://api.example.com:12345' should be used");
 	}
 
 	@Test
@@ -215,7 +215,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createResponseWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getContent()))
-				.isEqualTo("The uri 'http://api.example.com:12345' should be used");
+				.isEqualTo("The uri 'https://api.example.com:12345' should be used");
 	}
 
 	@Test
@@ -281,26 +281,26 @@ public class UriModifyingOperationPreprocessorTests {
 	@Test
 	public void urisInRequestHeadersCanBeModified() {
 		OperationRequest processed = this.preprocessor.host("api.example.com")
-				.preprocess(createRequestWithHeader("Foo", "http://locahost:12345"));
+				.preprocess(createRequestWithHeader("Foo", "https://locahost:12345"));
 		assertThat(processed.getHeaders().getFirst("Foo"))
-				.isEqualTo("http://api.example.com:12345");
+				.isEqualTo("https://api.example.com:12345");
 		assertThat(processed.getHeaders().getFirst("Host")).isEqualTo("api.example.com");
 	}
 
 	@Test
 	public void urisInResponseHeadersCanBeModified() {
 		OperationResponse processed = this.preprocessor.host("api.example.com")
-				.preprocess(createResponseWithHeader("Foo", "http://locahost:12345"));
+				.preprocess(createResponseWithHeader("Foo", "https://locahost:12345"));
 		assertThat(processed.getHeaders().getFirst("Foo"))
-				.isEqualTo("http://api.example.com:12345");
+				.isEqualTo("https://api.example.com:12345");
 	}
 
 	@Test
 	public void urisInRequestPartHeadersCanBeModified() {
 		OperationRequest processed = this.preprocessor.host("api.example.com").preprocess(
-				createRequestWithPartWithHeader("Foo", "http://locahost:12345"));
+				createRequestWithPartWithHeader("Foo", "https://locahost:12345"));
 		assertThat(processed.getParts().iterator().next().getHeaders().getFirst("Foo"))
-				.isEqualTo("http://api.example.com:12345");
+				.isEqualTo("https://api.example.com:12345");
 	}
 
 	@Test
@@ -309,7 +309,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createRequestWithPartWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getParts().iterator().next().getContent()))
-				.isEqualTo("The uri 'http://api.example.com:12345' should be used");
+				.isEqualTo("The uri 'https://api.example.com:12345' should be used");
 	}
 
 	@Test


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://alps.io/spec/ (200) with 3 occurrences could not be migrated:  
   ([https](https://alps.io/spec/) result AnnotatedConnectException).
* [ ] http://benalman.com/news/2010/11/immediately-invoked-function-expression/ (200) with 1 occurrences could not be migrated:  
   ([https](https://benalman.com/news/2010/11/immediately-invoked-function-expression/) result NotSslRecordException).
* [ ] http://rest-assured.io (200) with 1 occurrences could not be migrated:  
   ([https](https://rest-assured.io) result SSLHandshakeException).
* [ ] http://stateless.co/hal_specification.html (200) with 7 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).
* [ ] http://www.gregfranko.com/jquery.tocify.js/ (301) with 1 occurrences could not be migrated:  
   ([https](https://www.gregfranko.com/jquery.tocify.js/) result SSLHandshakeException).
* [ ] http://www.rest-assured.io (301) with 2 occurrences could not be migrated:  
   ([https](https://www.rest-assured.io) result SSLHandshakeException).
* [ ] http://example.com:80x/ (404) with 1 occurrences could not be migrated:  
   ([https](https://example.com:80x/) result NotSslRecordException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/ (301) with 2 occurrences migrated to:  
  https://johnresig.com/blog/ecmascript-5-strict-mode-json-and-more/ ([https](https://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/) result ClosedChannelException).
* [ ] http://jsperf.com/getall-vs-sizzle/2 (301) with 1 occurrences migrated to:  
  https://jsperf.com/getall-vs-sizzle/2 ([https](https://jsperf.com/getall-vs-sizzle/2) result ReadTimeoutException).
* [ ] http://api.foo.com:12345 (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://api.foo.com:12345 ([https](https://api.foo.com:12345) result ConnectTimeoutException).
* [ ] http://alpha.example.com (UnknownHostException) with 8 occurrences migrated to:  
  https://alpha.example.com ([https](https://alpha.example.com) result UnknownHostException).
* [ ] http://alpha.example.com/one (UnknownHostException) with 5 occurrences migrated to:  
  https://alpha.example.com/one ([https](https://alpha.example.com/one) result UnknownHostException).
* [ ] http://alpha.example.com/two (UnknownHostException) with 5 occurrences migrated to:  
  https://alpha.example.com/two ([https](https://alpha.example.com/two) result UnknownHostException).
* [ ] http://api.example.com (UnknownHostException) with 4 occurrences migrated to:  
  https://api.example.com ([https](https://api.example.com) result UnknownHostException).
* [ ] http://api.example.com/foo/bar (UnknownHostException) with 2 occurrences migrated to:  
  https://api.example.com/foo/bar ([https](https://api.example.com/foo/bar) result UnknownHostException).
* [ ] http://api.example.com:12345 (UnknownHostException) with 20 occurrences migrated to:  
  https://api.example.com:12345 ([https](https://api.example.com:12345) result UnknownHostException).
* [ ] http://api.example.com:12345/foo/bar (UnknownHostException) with 2 occurrences migrated to:  
  https://api.example.com:12345/foo/bar ([https](https://api.example.com:12345/foo/bar) result UnknownHostException).
* [ ] http://api.example.com:12345?foo=bar (UnknownHostException) with 2 occurrences migrated to:  
  https://api.example.com:12345?foo=bar ([https](https://api.example.com:12345?foo=bar) result UnknownHostException).
* [ ] http://api.example.com:23456 (UnknownHostException) with 2 occurrences migrated to:  
  https://api.example.com:23456 ([https](https://api.example.com:23456) result UnknownHostException).
* [ ] http://api.example.com?foo=bar (UnknownHostException) with 2 occurrences migrated to:  
  https://api.example.com?foo=bar ([https](https://api.example.com?foo=bar) result UnknownHostException).
* [ ] http://bravo.example.com (UnknownHostException) with 5 occurrences migrated to:  
  https://bravo.example.com ([https](https://bravo.example.com) result UnknownHostException).
* [ ] http://locahost:12345 (UnknownHostException) with 6 occurrences migrated to:  
  https://locahost:12345 ([https](https://locahost:12345) result UnknownHostException).
* [ ] http://tartaurs.org/~martin (UnknownHostException) with 1 occurrences migrated to:  
  https://tartaurs.org/~martin ([https](https://tartaurs.org/~martin) result UnknownHostException).
* [ ] http://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html (301) with 1 occurrences migrated to:  
  https://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html ([https](https://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html) result 403).
* [ ] http://appium.io/slate/en/master (404) with 1 occurrences migrated to:  
  https://appium.io/slate/en/master ([https](https://appium.io/slate/en/master) result 404).
* [ ] http://example.com/api/kittens (404) with 2 occurrences migrated to:  
  https://example.com/api/kittens ([https](https://example.com/api/kittens) result 404).
* [ ] http://example.com/api/kittens/2 (404) with 1 occurrences migrated to:  
  https://example.com/api/kittens/2 ([https](https://example.com/api/kittens/2) result 404).
* [ ] http://example.com/developers (404) with 1 occurrences migrated to:  
  https://example.com/developers ([https](https://example.com/developers) result 404).
* [ ] http://example.com/foo (404) with 2 occurrences migrated to:  
  https://example.com/foo ([https](https://example.com/foo) result 404).
* [ ] http://example.com/kittens/ (404) with 1 occurrences migrated to:  
  https://example.com/kittens/ ([https](https://example.com/kittens/) result 404).
* [ ] http://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/ (301) with 1 occurrences migrated to:  
  https://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/ ([https](https://fluidproject.org/blog/2008/01/09/getting-setting-and-removing-tabindex-values-with-javascript/) result 404).
* [ ] http://xml.apache.org/xslt (404) with 1 occurrences migrated to:  
  https://xml.apache.org/xslt ([https](https://xml.apache.org/xslt) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://api.jqueryui.com/jQuery.widget/ with 1 occurrences migrated to:  
  https://api.jqueryui.com/jQuery.widget/ ([https](https://api.jqueryui.com/jQuery.widget/) result 200).
* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/ with 2 occurrences migrated to:  
  https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/ ([https](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/) result 200).
* [ ] http://asciidoctor.org/docs/user-manual/ with 2 occurrences migrated to:  
  https://asciidoctor.org/docs/user-manual/ ([https](https://asciidoctor.org/docs/user-manual/) result 200).
* [ ] http://bugs.jquery.com/ticket/12359 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/12359 ([https](https://bugs.jquery.com/ticket/12359) result 200).
* [ ] http://bugs.jquery.com/ticket/13378 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/13378 ([https](https://bugs.jquery.com/ticket/13378) result 200).
* [ ] http://bugs.jquery.com/ticket/8235 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/8235 ([https](https://bugs.jquery.com/ticket/8235) result 200).
* [ ] http://bugs.jquery.com/ticket/9413 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/9413 ([https](https://bugs.jquery.com/ticket/9413) result 200).
* [ ] http://curl.haxx.se with 1 occurrences migrated to:  
  https://curl.haxx.se ([https](https://curl.haxx.se) result 200).
* [ ] http://developer.parrot.com/docs/bebop/ with 1 occurrences migrated to:  
  https://developer.parrot.com/docs/bebop/ ([https](https://developer.parrot.com/docs/bebop/) result 200).
* [ ] http://developers.cimediacloud.com with 1 occurrences migrated to:  
  https://developers.cimediacloud.com ([https](https://developers.cimediacloud.com) result 200).
* [ ] http://docs.fidor.de/ with 1 occurrences migrated to:  
  https://docs.fidor.de/ ([https](https://docs.fidor.de/) result 200).
* [ ] http://grails.org with 1 occurrences migrated to:  
  https://grails.org ([https](https://grails.org) result 200).
* [ ] http://httpie.org with 1 occurrences migrated to:  
  https://httpie.org ([https](https://httpie.org) result 200).
* [ ] http://jquery.com/ with 1 occurrences migrated to:  
  https://jquery.com/ ([https](https://jquery.com/) result 200).
* [ ] http://jqueryui.com with 2 occurrences migrated to:  
  https://jqueryui.com ([https](https://jqueryui.com) result 200).
* [ ] http://jsperf.com/thor-indexof-vs-for/5 with 1 occurrences migrated to:  
  https://jsperf.com/thor-indexof-vs-for/5 ([https](https://jsperf.com/thor-indexof-vs-for/5) result 200).
* [ ] http://junit.org/junit5/ with 1 occurrences migrated to:  
  https://junit.org/junit5/ ([https](https://junit.org/junit5/) result 200).
* [ ] http://localforage.github.io/localForage/ with 1 occurrences migrated to:  
  https://localforage.github.io/localForage/ ([https](https://localforage.github.io/localForage/) result 200).
* [ ] http://logback.qos.ch/manual/groovy.html with 1 occurrences migrated to:  
  https://logback.qos.ch/manual/groovy.html ([https](https://logback.qos.ch/manual/groovy.html) result 200).
* [ ] http://lunrjs.com with 1 occurrences migrated to:  
  https://lunrjs.com ([https](https://lunrjs.com) result 200).
* [ ] http://martinfowler.com/articles/richardsonMaturityModel.html with 12 occurrences migrated to:  
  https://martinfowler.com/articles/richardsonMaturityModel.html ([https](https://martinfowler.com/articles/richardsonMaturityModel.html) result 200).
* [ ] http://projects.spring.io/spring-data-rest/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-rest/ ([https](https://projects.spring.io/spring-data-rest/) result 200).
* [ ] http://projects.spring.io/spring-hateoas/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-hateoas/ ([https](https://projects.spring.io/spring-hateoas/) result 200).
* [ ] http://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html with 1 occurrences migrated to:  
  https://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html ([https](https://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html) result 200).
* [ ] http://saucelabs.com with 1 occurrences migrated to:  
  https://saucelabs.com ([https](https://saucelabs.com) result 200).
* [ ] http://sizzlejs.com/ with 2 occurrences migrated to:  
  https://sizzlejs.com/ ([https](https://sizzlejs.com/) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window ([https](https://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/ with 1 occurrences migrated to:  
  https://web.archive.org/web/20100324014747/http://blindsignals.com/index.php/2009/07/jquery-delay/ ([https](https://web.archive.org/web/20100324014747/https://blindsignals.com/index.php/2009/07/jquery-delay/) result 200).
* [ ] http://woocommerce.github.io/woocommerce-rest-api-docs/ with 1 occurrences migrated to:  
  https://woocommerce.github.io/woocommerce-rest-api-docs/ ([https](https://woocommerce.github.io/woocommerce-rest-api-docs/) result 200).
* [ ] http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html with 1 occurrences migrated to:  
  https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html ([https](https://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html) result 200).
* [ ] http://www.w3.org/TR/2011/REC-css3-selectors-20110929/ with 2 occurrences migrated to:  
  https://www.w3.org/TR/2011/REC-css3-selectors-20110929/ ([https](https://www.w3.org/TR/2011/REC-css3-selectors-20110929/) result 200).
* [ ] http://www.w3.org/TR/CSS21/syndata.html with 2 occurrences migrated to:  
  https://www.w3.org/TR/CSS21/syndata.html ([https](https://www.w3.org/TR/CSS21/syndata.html) result 200).
* [ ] http://www.w3.org/TR/DOM-Level-3-Events/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/DOM-Level-3-Events/ ([https](https://www.w3.org/TR/DOM-Level-3-Events/) result 200).
* [ ] http://www.w3.org/TR/selectors/ with 4 occurrences migrated to:  
  https://www.w3.org/TR/selectors/ ([https](https://www.w3.org/TR/selectors/) result 200).
* [ ] http://asciidoctor.org/docs/asciidoc-syntax-quick-reference with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/asciidoc-syntax-quick-reference ([https](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference) result 301).
* [ ] http://asciidoctor.org/docs/user-manual with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/user-manual ([https](https://asciidoctor.org/docs/user-manual) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://dev.w3.org/csswg/cssom/ with 1 occurrences migrated to:  
  https://dev.w3.org/csswg/cssom/ ([https](https://dev.w3.org/csswg/cssom/) result 301).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle) result 301).
* [ ] http://fortawesome.github.io/Font-Awesome/ with 1 occurrences migrated to:  
  https://fortawesome.github.io/Font-Awesome/ ([https](https://fortawesome.github.io/Font-Awesome/) result 301).
* [ ] http://github.com/tripit/slate with 1 occurrences migrated to:  
  https://github.com/tripit/slate ([https](https://github.com/tripit/slate) result 301).
* [ ] http://jquery.org/license with 3 occurrences migrated to:  
  https://jquery.org/license ([https](https://jquery.org/license) result 301).
* [ ] http://lord.github.io/slate with 1 occurrences migrated to:  
  https://lord.github.io/slate ([https](https://lord.github.io/slate) result 301).
* [ ] http://msdn.microsoft.com/en-us/library/ie/hh465388.aspx with 1 occurrences migrated to:  
  https://msdn.microsoft.com/en-us/library/ie/hh465388.aspx ([https](https://msdn.microsoft.com/en-us/library/ie/hh465388.aspx) result 301).
* [ ] http://projects.spring.io/spring-boot with 2 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).
* [ ] http://w3.org/TR/2012/WD-url-20120524/ with 1 occurrences migrated to:  
  https://w3.org/TR/2012/WD-url-20120524/ ([https](https://w3.org/TR/2012/WD-url-20120524/) result 301).
* [ ] http://www.w3.org/TR/css3-selectors/ with 1 occurrences migrated to:  
  https://www.w3.org/TR/css3-selectors/ ([https](https://www.w3.org/TR/css3-selectors/) result 301).
* [ ] http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx with 1 occurrences migrated to:  
  https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx ([https](https://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx) result 302).
* [ ] http://tartarus.org/~martin/PorterStemmer/js.txt with 2 occurrences migrated to:  
  https://tartarus.org/~martin/PorterStemmer/js.txt ([https](https://tartarus.org/~martin/PorterStemmer/js.txt) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 136 occurrences
* http://localhost/ with 2 occurrences
* http://localhost/foo with 94 occurrences
* http://localhost/foo/bar with 5 occurrences
* http://localhost/foo?a=alpha with 15 occurrences
* http://localhost/foo?a=alpha&a=apple&b=br%26vo with 3 occurrences
* http://localhost/foo?a=alpha&b=br%26vo with 2 occurrences
* http://localhost/foo?a=alpha&b=bravo with 13 occurrences
* http://localhost/foo?b=bravo with 2 occurrences
* http://localhost/foo?b=bravo&a=alpha with 1 occurrences
* http://localhost/foo?bar with 1 occurrences
* http://localhost/foo?bar=baz with 1 occurrences
* http://localhost/foo?param with 8 occurrences
* http://localhost/foo?param=value with 12 occurrences
* http://localhost/upload with 21 occurrences
* http://localhost:12345 with 30 occurrences
* http://localhost:12345/foo/bar with 5 occurrences
* http://localhost:12345?foo=%7B%7D with 2 occurrences
* http://localhost:12345?foo=bar with 4 occurrences
* http://localhost:23456 with 4 occurrences
* http://localhost:4567 with 2 occurrences
* http://localhost:8080 with 6 occurrences
* http://localhost:8080/ with 14 occurrences
* http://localhost:8080/?a=alpha with 2 occurrences
* http://localhost:8080/?foo=bar with 2 occurrences
* http://localhost:8080/custom/ with 1 occurrences
* http://localhost:8080/foo with 3 occurrences
* http://localhost:8080/tags/123 with 3 occurrences
* http://localhost:8080/test?foo=bar with 1 occurrences
* http://localhost?a=al%26%3Dpha with 1 occurrences
* http://localhost?a=alpha with 1 occurrences
* http://localhost?a=alpha&b=bravo&c=charlie with 1 occurrences
* http://localhost?a=apple&a=avocado with 1 occurrences
* http://localhost?a=apple=avocado with 1 occurrences
* http://localhost?foo=bar with 4 occurrences
* http://testng.org with 1 occurrences