### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -42,5 +42,5 @@ with regard to the reporter of an incident.
 This Code of Conduct is adapted from the [Contributor Covenant][1], version 1.3.0, available
 at [contributor-covenant.org/version/1/3/0/][2].
 
-[1]: http://contributor-covenant.org
-[2]: http://contributor-covenant.org/version/1/3/0/
+[1]: https://contributor-covenant.org
+[2]: https://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,4 +62,4 @@ The project can then be imported into Eclipse using `File -> Import…` and then
 
 [1]: CODE_OF_CONDUCT.md
 [2]: https://support.springsource.com/spring_committer_signup
-[3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[3]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/docs/src/docs/asciidoc/contributing.adoc
+++ b/docs/src/docs/asciidoc/contributing.adoc
@@ -9,7 +9,7 @@ for your RESTful services. However, we can't achieve that goal without your cont
 [[contributing-questions]]
 === Questions
 
-You can ask questions about Spring REST Docs on http://stackoverflow.com[StackOverflow]
+You can ask questions about Spring REST Docs on https://stackoverflow.com[StackOverflow]
 using the `spring-restdocs` tag. Similarly, we encourage you to help your fellow
 Spring REST Docs users by answering questions.
 

--- a/docs/src/docs/asciidoc/documenting-your-api.adoc
+++ b/docs/src/docs/asciidoc/documenting-your-api.adoc
@@ -444,7 +444,7 @@ A number of snippets are produced automatically when you document a call to
 |Snippet | Description
 
 | `curl-request.adoc`
-| Contains the http://curl.haxx.se[`curl`] command that is equivalent to the `MockMvc`
+| Contains the https://curl.haxx.se[`curl`] command that is equivalent to the `MockMvc`
 call that is being documented
 
 | `http-request.adoc`

--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -10,9 +10,9 @@ This section describes how to get started with Spring REST Docs.
 
 If you want to jump straight in, there are two sample applications available.
 {samples}/rest-notes-spring-hateoas[One sample] uses
-http://projects.spring.io/spring-hateoas/[Spring HATEOAS] and
+https://projects.spring.io/spring-hateoas/[Spring HATEOAS] and
 {samples}/rest-notes-spring-data-rest[the other] uses
-http://projects.spring.io/spring-data-rest/[Spring Data REST]. Both samples use
+https://projects.spring.io/spring-data-rest/[Spring Data REST]. Both samples use
 Spring REST Docs to produce a detailed API guide and a getting started walkthrough.
 
 Each sample contains a file named `api-guide.adoc` that produces an API guide for the
@@ -295,7 +295,7 @@ that can be produced by Spring REST Docs.
 === Using the snippets
 
 The generated snippets can be included in your documentation using the
-http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include macro].
+https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include macro].
 The `snippets` attribute specified in the <<getting-started-build-configuration, build
 configuration>> can be used to reference the snippets output directory. For example:
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -12,8 +12,8 @@ Andy Wilkinson
 :source: {github}/tree/{branch-or-tag}
 :samples: {source}/samples
 :templates: {source}spring-restdocs/src/main/resources/org/springframework/restdocs/templates
-:spring-boot-docs: http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle
-:spring-framework-docs: http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle
+:spring-boot-docs: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle
+:spring-framework-docs: https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle
 
 [[abstract]]
 

--- a/docs/src/docs/asciidoc/introduction.adoc
+++ b/docs/src/docs/asciidoc/introduction.adoc
@@ -6,7 +6,7 @@ services that is accurate and readable.
 
 Writing high-quality documentation is difficult. One way to ease that difficulty is to use
 tools that are well-suited to the job. To this end, Spring REST Docs uses
-http://asciidoctor.org[Asciidoctor]. Asciidoctor processes plain text and produces
+https://asciidoctor.org[Asciidoctor]. Asciidoctor processes plain text and produces
 HTML, styled and layed out to suit your needs.
 
 Spring REST Docs makes use of snippets produced by tests written with

--- a/docs/src/docs/asciidoc/working-with-asciidoctor.adoc
+++ b/docs/src/docs/asciidoc/working-with-asciidoctor.adoc
@@ -9,15 +9,15 @@ relevant to Spring REST Docs.
 [[working-with-asciidoctor-resources]]
 === Resources
 
- * http://asciidoctor.org/docs/asciidoc-syntax-quick-reference[Syntax quick reference]
- * http://asciidoctor.org/docs/user-manual[User manual]
+ * https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[Syntax quick reference]
+ * https://asciidoctor.org/docs/user-manual[User manual]
 
 
 
 [[working-with-asciidoctor-including-snippets]]
 === Including snippets
 
-The  http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include
+The  https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include
 macro] is used to include generated snippets in your documentation. The `snippets`
 attribute specified in the <<getting-started-build-configuration, build configuration>>
 can be used to reference the snippets output directory, for example:
@@ -42,7 +42,7 @@ snippet is included or by using a custom snippet template.
 ==== Formatting columns
 
 Asciidoctor has rich support for
-http://asciidoctor.org/docs/user-manual/#cols-format[formatting a table's columns]. For
+https://asciidoctor.org/docs/user-manual/#cols-format[formatting a table's columns]. For
 example, the widths of a table's columns can be specified using the `cols` attribute:
 
 [source,adoc,indent=0]
@@ -71,5 +71,5 @@ The title of a table can be specified using a line prefixed by a `.`:
 
 ==== Further reading
 
-Refer to the http://asciidoctor.org/docs/user-manual/#tables[Tables section of
+Refer to the https://asciidoctor.org/docs/user-manual/#tables[Tables section of
 the Asciidoctor user manual] for more information about customizing tables.

--- a/samples/rest-notes-spring-data-rest/src/main/asciidoc/getting-started-guide.adoc
+++ b/samples/rest-notes-spring-data-rest/src/main/asciidoc/getting-started-guide.adoc
@@ -20,7 +20,7 @@ to describe the relationships between resources and to allow navigation between 
 
 [getting-started-running-the-service]
 == Running the service
-RESTful Notes is written using http://projects.spring.io/spring-boot[Spring Boot] which
+RESTful Notes is written using https://projects.spring.io/spring-boot[Spring Boot] which
 makes it easy to get it up and running so that you can start exploring the REST API.
 
 The first step is to clone the Git repository:

--- a/samples/rest-notes-spring-data-rest/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-spring-data-rest/src/test/java/com/example/notes/ApiDocumentation.java
@@ -125,7 +125,7 @@ public class ApiDocumentation {
 		this.noteRepository.deleteAll();
 
 		createNote("REST maturity model",
-				"http://martinfowler.com/articles/richardsonMaturityModel.html");
+				"https://martinfowler.com/articles/richardsonMaturityModel.html");
 		createNote("Hypertext Application Language (HAL)",
 				"http://stateless.co/hal_specification.html");
 		createNote("Application-Level Profile Semantics (ALPS)", "http://alps.io/spec/");
@@ -151,7 +151,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		this.mockMvc.perform(
@@ -179,7 +179,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		String noteLocation = this.mockMvc
@@ -239,7 +239,7 @@ public class ApiDocumentation {
 	public void noteUpdateExample() throws Exception {
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 
 		String noteLocation = this.mockMvc
 				.perform(

--- a/samples/rest-notes-spring-hateoas/src/docs/asciidoc/getting-started-guide.adoc
+++ b/samples/rest-notes-spring-hateoas/src/docs/asciidoc/getting-started-guide.adoc
@@ -20,7 +20,7 @@ to describe the relationships between resources and to allow navigation between 
 
 [getting-started-running-the-service]
 == Running the service
-RESTful Notes is written using http://projects.spring.io/spring-boot[Spring Boot] which
+RESTful Notes is written using https://projects.spring.io/spring-boot[Spring Boot] which
 makes it easy to get it up and running so that you can start exploring the REST API.
 
 The first step is to clone the Git repository:

--- a/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java
@@ -151,7 +151,7 @@ public class ApiDocumentation {
 		this.noteRepository.deleteAll();
 
 		createNote("REST maturity model",
-				"http://martinfowler.com/articles/richardsonMaturityModel.html");
+				"https://martinfowler.com/articles/richardsonMaturityModel.html");
 		createNote("Hypertext Application Language (HAL)",
 				"http://stateless.co/hal_specification.html");
 		createNote("Application-Level Profile Semantics (ALPS)", "http://alps.io/spec/");
@@ -178,7 +178,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		ConstrainedFields fields = new ConstrainedFields(NoteInput.class);
@@ -209,7 +209,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		String noteLocation = this.mockMvc
@@ -275,7 +275,7 @@ public class ApiDocumentation {
 	public void noteUpdateExample() throws Exception {
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 
 		String noteLocation = this.mockMvc
 				.perform(

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HypermediaDocumentation.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HypermediaDocumentation.java
@@ -146,7 +146,7 @@ public abstract class HypermediaDocumentation {
 	 * {
 	 *     "_links": {
 	 *         "self": {
-	 *             "href": "http://example.com/foo"
+	 *             "href": "https://example.com/foo"
 	 *         }
 	 *     }
 	 * }
@@ -167,7 +167,7 @@ public abstract class HypermediaDocumentation {
 	 *     "links": [
 	 *         {
 	 *             "rel": "self",
-	 *             "href": "http://example.com/foo"
+	 *             "href": "https://example.com/foo"
 	 *         }
 	 *     ]
 	 * }

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/PrettyPrintingContentModifier.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/PrettyPrintingContentModifier.java
@@ -82,7 +82,7 @@ public class PrettyPrintingContentModifier implements ContentModifier {
 		public byte[] prettyPrint(byte[] original) throws Exception {
 			Transformer transformer = TransformerFactory.newInstance().newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount",
+			transformer.setOutputProperty("{https://xml.apache.org/xslt}indent-amount",
 					"4");
 			transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "yes");
 			ByteArrayOutputStream transformed = new ByteArrayOutputStream();

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsPayloadTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsPayloadTests.java
@@ -68,23 +68,23 @@ public class LinkExtractorsPayloadTests {
 	public void singleLink() throws IOException {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("single-link"));
-		assertLinks(Arrays.asList(new Link("alpha", "http://alpha.example.com")), links);
+		assertLinks(Arrays.asList(new Link("alpha", "https://alpha.example.com")), links);
 	}
 
 	@Test
 	public void multipleLinksWithDifferentRels() throws IOException {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("multiple-links-different-rels"));
-		assertLinks(Arrays.asList(new Link("alpha", "http://alpha.example.com"),
-				new Link("bravo", "http://bravo.example.com")), links);
+		assertLinks(Arrays.asList(new Link("alpha", "https://alpha.example.com"),
+				new Link("bravo", "https://bravo.example.com")), links);
 	}
 
 	@Test
 	public void multipleLinksWithSameRels() throws IOException {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("multiple-links-same-rels"));
-		assertLinks(Arrays.asList(new Link("alpha", "http://alpha.example.com/one"),
-				new Link("alpha", "http://alpha.example.com/two")), links);
+		assertLinks(Arrays.asList(new Link("alpha", "https://alpha.example.com/one"),
+				new Link("alpha", "https://alpha.example.com/two")), links);
 	}
 
 	@Test

--- a/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-embedded-and-links.json
+++ b/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-embedded-and-links.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
-		"alpha": "http://alpha.example.com",
-		"bravo": "http://bravo.example.com"
+		"alpha": "https://alpha.example.com",
+		"bravo": "https://bravo.example.com"
 	},
 	"_embedded": "embedded-test",
 	"beta": "beta-value",

--- a/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-links.json
+++ b/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-links.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
-		"alpha": "http://alpha.example.com",
-		"bravo": "http://bravo.example.com"
+		"alpha": "https://alpha.example.com",
+		"bravo": "https://bravo.example.com"
 	},
 	"beta": "beta-value",
 	"charlie": "charlie-value"

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-different-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-different-rels.json
@@ -1,9 +1,9 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com"
+		"href": "https://alpha.example.com"
 	}, {
 		"rel": "bravo",
-		"href": "http://bravo.example.com"
+		"href": "https://bravo.example.com"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-same-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-same-rels.json
@@ -1,9 +1,9 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/one"
+		"href": "https://alpha.example.com/one"
 	}, {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/two"
+		"href": "https://alpha.example.com/two"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/single-link.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/single-link.json
@@ -1,6 +1,6 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com"
+		"href": "https://alpha.example.com"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/wrong-format.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/wrong-format.json
@@ -1,9 +1,9 @@
 {
 	"links": {
 		"alpha": [{
-		    "href": "http://alpha.example.com/one"
+		    "href": "https://alpha.example.com/one"
 		}, {
-		    "href": "http://alpha.example.com/two"
+		    "href": "https://alpha.example.com/two"
 		}]
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-different-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-different-rels.json
@@ -1,10 +1,10 @@
 {
 	"_links": {
 		"alpha": {
-			"href": "http://alpha.example.com"
+			"href": "https://alpha.example.com"
 		},
 		"bravo": {
-			"href": "http://bravo.example.com"
+			"href": "https://bravo.example.com"
 		}
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-same-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-same-rels.json
@@ -1,9 +1,9 @@
 {
 	"_links": {
 		"alpha": [{
-		    "href": "http://alpha.example.com/one"
+		    "href": "https://alpha.example.com/one"
 		}, {
-		    "href": "http://alpha.example.com/two"
+		    "href": "https://alpha.example.com/two"
 		}]
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/single-link.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/single-link.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
 		"alpha": {
-		    "href": "http://alpha.example.com"
+		    "href": "https://alpha.example.com"
 		}
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/wrong-format.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/wrong-format.json
@@ -1,9 +1,9 @@
 {
 	"_links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/one"
+		"href": "https://alpha.example.com/one"
 	}, {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/two"
+		"href": "https://alpha.example.com/two"
 	} ]
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://alps.io/spec/ (200) with 2 occurrences could not be migrated:  
   ([https](https://alps.io/spec/) result AnnotatedConnectException).
* [ ] http://stateless.co/hal_specification.html (200) with 5 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://alpha.example.com (UnknownHostException) with 8 occurrences migrated to:  
  https://alpha.example.com ([https](https://alpha.example.com) result UnknownHostException).
* [ ] http://alpha.example.com/one (UnknownHostException) with 5 occurrences migrated to:  
  https://alpha.example.com/one ([https](https://alpha.example.com/one) result UnknownHostException).
* [ ] http://alpha.example.com/two (UnknownHostException) with 5 occurrences migrated to:  
  https://alpha.example.com/two ([https](https://alpha.example.com/two) result UnknownHostException).
* [ ] http://bravo.example.com (UnknownHostException) with 5 occurrences migrated to:  
  https://bravo.example.com ([https](https://bravo.example.com) result UnknownHostException).
* [ ] http://example.com/foo (404) with 2 occurrences migrated to:  
  https://example.com/foo ([https](https://example.com/foo) result 404).
* [ ] http://xml.apache.org/xslt (404) with 1 occurrences migrated to:  
  https://xml.apache.org/xslt ([https](https://xml.apache.org/xslt) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/ with 2 occurrences migrated to:  
  https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/ ([https](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/) result 200).
* [ ] http://asciidoctor.org/docs/user-manual/ with 2 occurrences migrated to:  
  https://asciidoctor.org/docs/user-manual/ ([https](https://asciidoctor.org/docs/user-manual/) result 200).
* [ ] http://curl.haxx.se with 1 occurrences migrated to:  
  https://curl.haxx.se ([https](https://curl.haxx.se) result 200).
* [ ] http://martinfowler.com/articles/richardsonMaturityModel.html with 8 occurrences migrated to:  
  https://martinfowler.com/articles/richardsonMaturityModel.html ([https](https://martinfowler.com/articles/richardsonMaturityModel.html) result 200).
* [ ] http://projects.spring.io/spring-data-rest/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-rest/ ([https](https://projects.spring.io/spring-data-rest/) result 200).
* [ ] http://projects.spring.io/spring-hateoas/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-hateoas/ ([https](https://projects.spring.io/spring-hateoas/) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://asciidoctor.org/docs/asciidoc-syntax-quick-reference with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/asciidoc-syntax-quick-reference ([https](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference) result 301).
* [ ] http://asciidoctor.org/docs/user-manual with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/user-manual ([https](https://asciidoctor.org/docs/user-manual) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle) result 301).
* [ ] http://projects.spring.io/spring-boot with 2 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 36 occurrences
* http://localhost/ with 2 occurrences
* http://localhost/foo with 39 occurrences
* http://localhost/foo/bar with 1 occurrences
* http://localhost/foo?a=alpha with 4 occurrences
* http://localhost/foo?a=alpha&a=apple&b=br%26vo with 1 occurrences
* http://localhost/foo?a=alpha&b=bravo with 1 occurrences
* http://localhost/foo?bar with 1 occurrences
* http://localhost/foo?bar=baz with 1 occurrences
* http://localhost/foo?param with 4 occurrences
* http://localhost/foo?param=value with 4 occurrences
* http://localhost/upload with 12 occurrences
* http://localhost:8080/ with 1 occurrences
* http://localhost:8080/?foo=bar with 1 occurrences
* http://localhost:8080/custom/ with 1 occurrences
* http://localhost:8080/foo with 1 occurrences
* http://localhost:8080/tags/123 with 2 occurrences
* http://localhost?a=al%26%3Dpha with 1 occurrences
* http://localhost?a=alpha with 1 occurrences
* http://localhost?a=alpha&b=bravo&c=charlie with 1 occurrences
* http://localhost?a=apple&a=avocado with 1 occurrences
* http://localhost?a=apple=avocado with 1 occurrences