### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -42,5 +42,5 @@ with regard to the reporter of an incident.
 This Code of Conduct is adapted from the [Contributor Covenant][1], version 1.3.0, available
 at [contributor-covenant.org/version/1/3/0/][2].
 
-[1]: http://contributor-covenant.org
-[2]: http://contributor-covenant.org/version/1/3/0/
+[1]: https://contributor-covenant.org
+[2]: https://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,4 +61,4 @@ The project can then be imported into Eclipse using `File -> Import…` and then
 
 [1]: CODE_OF_CONDUCT.md
 [2]: https://cla.pivotal.io/sign/spring
-[3]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+[3]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/docs/src/docs/asciidoc/contributing.adoc
+++ b/docs/src/docs/asciidoc/contributing.adoc
@@ -9,7 +9,7 @@ for your RESTful services. However, we can't achieve that goal without your cont
 [[contributing-questions]]
 === Questions
 
-You can ask questions about Spring REST Docs on http://stackoverflow.com[StackOverflow]
+You can ask questions about Spring REST Docs on https://stackoverflow.com[StackOverflow]
 using the `spring-restdocs` tag. Similarly, we encourage you to help your fellow
 Spring REST Docs users by answering questions.
 

--- a/docs/src/docs/asciidoc/documenting-your-api.adoc
+++ b/docs/src/docs/asciidoc/documenting-your-api.adoc
@@ -765,11 +765,11 @@ A number of snippets are produced automatically when you document a request and 
 |Snippet | Description
 
 | `curl-request.adoc`
-| Contains the http://curl.haxx.se[`curl`] command that is equivalent to the `MockMvc`
+| Contains the https://curl.haxx.se[`curl`] command that is equivalent to the `MockMvc`
 call that is being documented
 
 | `httpie-request.adoc`
-| Contains the http://httpie.org[`HTTPie`] command that is equivalent to the `MockMvc`
+| Contains the https://httpie.org[`HTTPie`] command that is equivalent to the `MockMvc`
 call that is being documented
 
 | `http-request.adoc`

--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -19,12 +19,12 @@ If you want to jump straight in, a number of sample applications are available:
 | {samples}/rest-notes-spring-data-rest[Spring Data REST]
 | Maven
 | Demonstrates the creation of a getting started guide and an API guide for a service
-  implemented using http://projects.spring.io/spring-data-rest/[Spring Data REST].
+  implemented using https://projects.spring.io/spring-data-rest/[Spring Data REST].
 
 | {samples}/rest-notes-spring-hateoas[Spring HATEOAS]
 | Gradle
 | Demonstrates the creation of a getting started guide and an API guide for a service
-  implemented using http://projects.spring.io/spring-hateoas/[Spring HATEOAS].
+  implemented using https://projects.spring.io/spring-hateoas/[Spring HATEOAS].
 
 |===
 
@@ -54,7 +54,7 @@ If you want to jump straight in, a number of sample applications are available:
 | {samples}/rest-notes-slate[Slate]
 | Gradle
 | Demonstrates the use of Spring REST Docs with Markdown and
-  http://github.com/tripit/slate[Slate].
+  https://github.com/tripit/slate[Slate].
 
 | {samples}/testng[TestNG]
 | Gradle
@@ -244,7 +244,7 @@ from where it will be included in the jar file.
 === Generating documentation snippets
 Spring REST Docs uses
 {spring-framework-docs}/#spring-mvc-test-framework[Spring's MVC Test framework] or
-http://www.rest-assured.io[REST Assured] to make requests to the service that you are
+http://rest-assured.io/[REST Assured] to make requests to the service that you are
 documenting. It then produces documentation snippets for the request and the resulting
 response.
 
@@ -430,7 +430,7 @@ the resulting HTML files depends on whether you are using Maven or Gradle:
 
 The generated snippets can then be included in the manually created Asciidoctor file from
 above using the
-http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include macro].
+https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include macro].
 The `snippets` attribute specified in the <<getting-started-build-configuration, build
 configuration>> can be used to reference the snippets output directory. For example:
 

--- a/docs/src/docs/asciidoc/index.adoc
+++ b/docs/src/docs/asciidoc/index.adoc
@@ -12,8 +12,8 @@ Andy Wilkinson
 :source: {github}/tree/{branch-or-tag}
 :samples: {source}/samples
 :templates: {source}spring-restdocs/src/main/resources/org/springframework/restdocs/templates
-:spring-boot-docs: http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle
-:spring-framework-docs: http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle
+:spring-boot-docs: https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle
+:spring-framework-docs: https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle
 
 [[abstract]]
 

--- a/docs/src/docs/asciidoc/introduction.adoc
+++ b/docs/src/docs/asciidoc/introduction.adoc
@@ -6,13 +6,13 @@ services that is accurate and readable.
 
 Writing high-quality documentation is difficult. One way to ease that difficulty is to use
 tools that are well-suited to the job. To this end, Spring REST Docs uses
-http://asciidoctor.org[Asciidoctor] by default. Asciidoctor processes plain text and
+https://asciidoctor.org[Asciidoctor] by default. Asciidoctor processes plain text and
 produces HTML, styled and layed out to suit your needs. If you prefer, Spring REST Docs
 can also be configured to use Markdown.
 
 Spring REST Docs makes use of snippets produced by tests written with
 {spring-framework-docs}/#spring-mvc-test-framework[Spring MVC Test] or
-http://www.rest-assured.io[REST Assured]. This test-driven approach helps to guarantee the
+http://rest-assured.io/[REST Assured]. This test-driven approach helps to guarantee the
 accuracy of your service's documentation. If a snippet is incorrect the test that produces
 it will fail.
 

--- a/docs/src/docs/asciidoc/working-with-asciidoctor.adoc
+++ b/docs/src/docs/asciidoc/working-with-asciidoctor.adoc
@@ -9,15 +9,15 @@ relevant to Spring REST Docs.
 [[working-with-asciidoctor-resources]]
 === Resources
 
- * http://asciidoctor.org/docs/asciidoc-syntax-quick-reference[Syntax quick reference]
- * http://asciidoctor.org/docs/user-manual[User manual]
+ * https://asciidoctor.org/docs/asciidoc-syntax-quick-reference[Syntax quick reference]
+ * https://asciidoctor.org/docs/user-manual[User manual]
 
 
 
 [[working-with-asciidoctor-including-snippets]]
 === Including snippets
 
-The  http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include
+The  https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#include-files[include
 macro] is used to include generated snippets in your documentation. The `snippets`
 attribute specified in the <<getting-started-build-configuration, build configuration>>
 can be used to reference the snippets output directory, for example:
@@ -42,7 +42,7 @@ snippet is included or by using a custom snippet template.
 ==== Formatting columns
 
 Asciidoctor has rich support for
-http://asciidoctor.org/docs/user-manual/#cols-format[formatting a table's columns]. For
+https://asciidoctor.org/docs/user-manual/#cols-format[formatting a table's columns]. For
 example, the widths of a table's columns can be specified using the `cols` attribute:
 
 [source,indent=0]
@@ -89,5 +89,5 @@ in a cell that contains the value of a `description` attribute:
 
 ==== Further reading
 
-Refer to the http://asciidoctor.org/docs/user-manual/#tables[Tables section of
+Refer to the https://asciidoctor.org/docs/user-manual/#tables[Tables section of
 the Asciidoctor user manual] for more information about customizing tables.

--- a/samples/rest-notes-grails/README.md
+++ b/samples/rest-notes-grails/README.md
@@ -3,7 +3,7 @@
 ## Overview
 
 This is a sample project using Grails 3, Spock, and Spring REST docs. For more
-information about the Grails framework please see [grails.org](http://grails.org).
+information about the Grails framework please see [grails.org](https://grails.org).
 
 Grails is built on top of Spring Boot and Gradle so there are a few different ways to
 run this project including:

--- a/samples/rest-notes-grails/grails-app/conf/logback.groovy
+++ b/samples/rest-notes-grails/grails-app/conf/logback.groovy
@@ -17,7 +17,7 @@
 import grails.util.BuildSettings
 import grails.util.Environment
 
-// See http://logback.qos.ch/manual/groovy.html for details on configuration
+// See https://logback.qos.ch/manual/groovy.html for details on configuration
 appender('STDOUT', ConsoleAppender) {
 	encoder(PatternLayoutEncoder) {
 		pattern = "%level %logger - %msg%n"

--- a/samples/rest-notes-slate/README.md
+++ b/samples/rest-notes-slate/README.md
@@ -21,4 +21,4 @@ documentation by [ERB][4]. The combined Markdown document is then turned into HT
 [1]: https://github.com/tripit/slate
 [2]: slate/api-guide.md.erb
 [3]: src/test/java/com/example/notes/ApiDocumentation.java
-[4]: http://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html
+[4]: https://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html

--- a/samples/rest-notes-slate/slate/README.md
+++ b/samples/rest-notes-slate/slate/README.md
@@ -7,7 +7,7 @@ Slate helps you create beautiful API documentation. Think of it as an intelligen
 
 <img src="https://dl.dropboxusercontent.com/u/95847291/github%20images/slate/slate_screenshot_new.png" width=700 alt="Screenshot of Example Documentation created with Slate">
 
-*The example above was created with Slate. Check it out at [tripit.github.io/slate](http://tripit.github.io/slate).*
+*The example above was created with Slate. Check it out at [tripit.github.io/slate](https://tripit.github.io/slate).*
 
 Features
 ------------
@@ -20,15 +20,15 @@ Features
 
 * **Write code samples in multiple languages** — if your API has bindings in multiple programming languages, you easily put in tabs to switch between them. In your document, you'll distinguish different languages by specifying the language name at the top of each code block, just like with Github Flavored Markdown!
 
-* **Out-of-the-box syntax highlighting** for [almost 60 languages](http://rouge.jayferd.us/demo), no configuration required.
+* **Out-of-the-box syntax highlighting** for [almost 60 languages](https://rouge.jayferd.us/demo), no configuration required.
 
 * **Automatic, smoothly scrolling table of contents** on the far left of the page. As you scroll, it displays your current position in the document. It's fast, too. We're using Slate at TripIt to build documentation for our new API, where our table of contents has over 180 entries. We've made sure that the performance remains excellent, even for larger documents.
 
 * **Let your users update your documentation for you** — by default, your Slate-generated documentation is hosted in a public Github repository. Not only does this mean you get free hosting for your docs with Github Pages, but it also makes it's simple for other developers to make pull requests to your docs if they find typos or other problems. Of course, if you don't want to, you're welcome to not use Github and host your docs elsewhere!
 
-Getting starting with Slate is super easy! Simply fork this repository, and then follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](http://tripit.github.io/slate).
+Getting starting with Slate is super easy! Simply fork this repository, and then follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](https://tripit.github.io/slate).
 
-<!--As an example, you can check out the [TripIt API docs](http://tripit.github.io/api), which we create with Slate. You can also view the source of the [markdown file used to generate it](http://github.com/tripit/api/blob/master/source/index.md).-->
+<!--As an example, you can check out the [TripIt API docs](https://tripit.github.io/api), which we create with Slate. You can also view the source of the [markdown file used to generate it](https://github.com/tripit/api/blob/master/source/index.md).-->
 
 Getting Started with Slate
 ------------------------------
@@ -66,34 +66,34 @@ Now that Slate is all set up your machine, you'll probably want to learn more ab
 Examples of Slate in the Wild
 ---------------------------------
 
-* [Travis-CI's API docs](http://docs.travis-ci.com/api/)
-* [Mozilla's localForage docs](http://mozilla.github.io/localForage/)
-* [Mozilla Recroom](http://mozilla.github.io/recroom/)
-* [ChaiOne Gameplan API docs](http://chaione.github.io/gameplanb2b/#introduction)
-* [Drcaban's Build a Quine tutorial](http://drcabana.github.io/build-a-quine/#introduction)
+* [Travis-CI's API docs](https://docs.travis-ci.com/api/)
+* [Mozilla's localForage docs](https://mozilla.github.io/localForage/)
+* [Mozilla Recroom](https://mozilla.github.io/recroom/)
+* [ChaiOne Gameplan API docs](https://chaione.github.io/gameplanb2b/#introduction)
+* [Drcaban's Build a Quine tutorial](https://drcabana.github.io/build-a-quine/#introduction)
 * [PricePlow API docs](https://www.priceplow.com/api/documentation)
-* [Emerging Threats API docs](http://apidocs.emergingthreats.net/)
-* [Appium docs](http://appium.io/slate/en/master)
-* [Golazon Developer](http://developer.golazon.com)
+* [Emerging Threats API docs](https://apidocs.emergingthreats.net/)
+* [Appium docs](https://appium.io/slate/en/master)
+* [Golazon Developer](https://developer.golazon.com)
 * [Dwolla API docs](https://docs.dwolla.com/)
-* [RozpisyZapasu API docs](http://www.rozpisyzapasu.cz/dev/api/)
-* [Codestar Framework Docs](http://codestarframework.com/documentation/)
+* [RozpisyZapasu API docs](https://www.rozpisyzapasu.cz/dev/api/)
+* [Codestar Framework Docs](https://codestarframework.com/documentation/)
 * [Buddycloud API](http://buddycloud.com/api)
 * [Crafty Clicks API](https://craftyclicks.co.uk/api/)
 * [Paracel API Reference](http://paracel.io/docs/api_reference.html)
-* [Switch Payments Documentation](http://switchpayments.com/docs/) & [API](http://switchpayments.com/developers/)
+* [Switch Payments Documentation](https://switchpayments.com/docs/) & [API](https://switchpayments.com/developers/)
 * [Coinbase API Reference](https://developers.coinbase.com/api)
 * [Whispir.io API](https://whispir.github.io/api)
 * [NASA API](https://data.nasa.gov/developer/external/planetary/)
 * [CardPay API](https://developers.cardpay.com/)
 * [IBM Cloudant](https://docs-testb.cloudant.com/content-review/_design/couchapp/index.html)
-* [Bitrix basis components](http://bbc.bitrix.expert/)
-* [viagogo API Documentation](http://developer.viagogo.net/)
-* [Fidor Bank API Documentation](http://docs.fidor.de/)
-* [Market Prophit API Documentation](http://developer.marketprophit.com/)
-* [OAuth.io API Documentation](http://docs.oauth.io/)
-* [Aircall for Developers](http://developer.aircall.io/)
-* [SupportKit API Docs](http://docs.supportkit.io/)
+* [Bitrix basis components](https://bbc.bitrix.expert/)
+* [viagogo API Documentation](https://developer.viagogo.net/)
+* [Fidor Bank API Documentation](https://docs.fidor.de/)
+* [Market Prophit API Documentation](https://developer.marketprophit.com/)
+* [OAuth.io API Documentation](https://docs.oauth.io/)
+* [Aircall for Developers](https://developer.aircall.io/)
+* [SupportKit API Docs](https://docs.smooch.io/)
 * [SocialRadar's LocationKit Docs](https://docs.locationkit.io/)
 * [SafetyCulture API Documentation](https://developer.safetyculture.io/)
 * [hosting.de API Documentation](https://www.hosting.de/docs/api/)
@@ -109,7 +109,7 @@ Just [submit a issue](https://github.com/tripit/slate/issues) to the Slate Githu
 Contributors
 --------------------
 
-Slate was built by [Robert Lord](https://lord.io) while at [TripIt](http://tripit.com).
+Slate was built by [Robert Lord](https://lord.io) while at [TripIt](https://tripit.com).
 
 Thanks to the following people who have submitted major pull requests:
 
@@ -117,7 +117,7 @@ Thanks to the following people who have submitted major pull requests:
 - [@bootstraponline](https://github.com/bootstraponline)
 - [@realityking](https://github.com/realityking)
 
-Also, thanks to [Sauce Labs](http://saucelabs.com) for helping sponsor the project.
+Also, thanks to [Sauce Labs](https://saucelabs.com) for helping sponsor the project.
 
 Special Thanks
 --------------------
@@ -125,4 +125,4 @@ Special Thanks
 - [jquery.tocify.js](https://github.com/gfranko/jquery.tocify.js)
 - [middleman-syntax](https://github.com/middleman/middleman-syntax)
 - [middleman-gh-pages](https://github.com/neo/middleman-gh-pages)
-- [Font Awesome](http://fortawesome.github.io/Font-Awesome/)
+- [Font Awesome](https://fortawesome.github.io/Font-Awesome/)

--- a/samples/rest-notes-slate/slate/source/javascripts/app/_lang.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/app/_lang.js
@@ -61,7 +61,7 @@ under the License.
 
       key = decodeURIComponent(key);
       // missing `=` should be `null`:
-      // http://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
+      // https://w3.org/TR/2012/WD-url-20120524/#collect-url-parameters
       val = val === undefined ? null : decodeURIComponent(val);
 
       if (!ret.hasOwnProperty(key)) {

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_energize.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_energize.js
@@ -115,7 +115,7 @@
 
     /** 
      * Special logic for standalone web apps
-     * See http://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window
+     * See https://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window
      */
     if(standAlone) {
       window.location = target.getAttribute("href");

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.highlight.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.highlight.js
@@ -2,7 +2,7 @@
  * jQuery Highlight plugin
  *
  * Based on highlight v3 by Johann Burkard
- * http://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html
+ * https://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html
  *
  * Code a little bit refactored and cleaned (in my humble opinion).
  * Most important changes:

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.tocify.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery.tocify.js
@@ -1,5 +1,5 @@
 /* jquery Tocify - v1.8.0 - 2013-09-16
-* http://www.gregfranko.com/jquery.tocify.js/
+* http://gregfranko.com/jquery.tocify.js/
 * Copyright (c) 2013 Greg Franko; Licensed MIT
 * Modified lightly by Robert Lord to fix a bug I found,
 * and also so it adds ids to headers
@@ -10,7 +10,7 @@
 // Immediately-Invoked Function Expression (IIFE) [Ben Alman Blog Post](http://benalman.com/news/2010/11/immediately-invoked-function-expression/) that calls another IIFE that contains all of the plugin logic.  I used this pattern so that anyone viewing this code would not have to scroll to the bottom of the page to view the local parameters that were passed to the main IIFE.
 (function(tocify) {
 
-    // ECMAScript 5 Strict Mode: [John Resig Blog Post](http://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/)
+    // ECMAScript 5 Strict Mode: [John Resig Blog Post](https://johnresig.com/blog/ecmascript-5-strict-mode-json-and-more/)
     "use strict";
 
     // Calls the second IIFE and locally passes in the global jQuery, window, and document objects
@@ -21,7 +21,7 @@
 // Locally passes in `jQuery`, the `window` object, the `document` object, and an `undefined` variable.  The `jQuery`, `window` and `document` objects are passed in locally, to improve performance, since javascript first searches for a variable match within the local variables set before searching the global variables set.  All of the global variables are also passed in locally to be minifier friendly. `undefined` can be passed in locally, because it is not a reserved word in JavaScript.
 (function($, window, document, undefined) {
 
-    // ECMAScript 5 Strict Mode: [John Resig Blog Post](http://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/)
+    // ECMAScript 5 Strict Mode: [John Resig Blog Post](https://johnresig.com/blog/ecmascript-5-strict-mode-json-and-more/)
     "use strict";
 
     var tocClassName = "tocify",

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery_ui.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_jquery_ui.js
@@ -1,5 +1,5 @@
 /*! jQuery UI - v1.11.3 - 2015-02-12
- * http://jqueryui.com
+ * https://jqueryui.com
  * Includes: widget.js
  * Copyright 2015 jQuery Foundation and other contributors; Licensed MIT */
 
@@ -16,13 +16,13 @@
 }(function( $ ) {
   /*!
    * jQuery UI Widget 1.11.3
-   * http://jqueryui.com
+   * https://jqueryui.com
    *
    * Copyright jQuery Foundation and other contributors
    * Released under the MIT license.
-   * http://jquery.org/license
+   * https://jquery.org/license
    *
-   * http://api.jqueryui.com/jQuery.widget/
+   * https://api.jqueryui.com/jQuery.widget/
    */
 
 
@@ -41,7 +41,7 @@
             $( elem ).triggerHandler( "remove" );
           }
 
-          // http://bugs.jquery.com/ticket/8235
+          // https://bugs.jquery.com/ticket/8235
         } catch ( e ) {}
       }
       orig( elems );
@@ -305,7 +305,7 @@
           .unbind( this.eventNamespace )
           .removeData( this.widgetFullName )
         // support: jquery <1.6.3
-        // http://bugs.jquery.com/ticket/9413
+        // https://bugs.jquery.com/ticket/9413
           .removeData( $.camelCase( this.widgetFullName ) );
       this.widget()
           .unbind( this.eventNamespace )

--- a/samples/rest-notes-slate/slate/source/javascripts/lib/_lunr.js
+++ b/samples/rest-notes-slate/slate/source/javascripts/lib/_lunr.js
@@ -1,5 +1,5 @@
 /**
- * lunr - http://lunrjs.com - A bit like Solr, but much smaller and not as bright - 0.5.7
+ * lunr - https://lunrjs.com - A bit like Solr, but much smaller and not as bright - 0.5.7
  * Copyright (C) 2014 Oliver Nightingale
  * MIT Licensed
  * @license
@@ -1298,12 +1298,12 @@
   /*!
    * lunr.stemmer
    * Copyright (C) 2014 Oliver Nightingale
-   * Includes code from - http://tartarus.org/~martin/PorterStemmer/js.txt
+   * Includes code from - https://tartarus.org/~martin/PorterStemmer/js.txt
    */
 
   /**
    * lunr.stemmer is an english language stemmer, this is a JavaScript
-   * implementation of the PorterStemmer taken from http://tartaurs.org/~martin
+   * implementation of the PorterStemmer taken from https://tartaurs.org/~martin
    *
    * @module
    * @param {String} str The string to stem
@@ -1689,7 +1689,7 @@
   /*!
    * lunr.stemmer
    * Copyright (C) 2014 Oliver Nightingale
-   * Includes code from - http://tartarus.org/~martin/PorterStemmer/js.txt
+   * Includes code from - https://tartarus.org/~martin/PorterStemmer/js.txt
    */
 
   /**

--- a/samples/rest-notes-slate/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-slate/src/test/java/com/example/notes/ApiDocumentation.java
@@ -126,7 +126,7 @@ public class ApiDocumentation {
 		this.noteRepository.deleteAll();
 
 		createNote("REST maturity model",
-				"http://martinfowler.com/articles/richardsonMaturityModel.html");
+				"https://martinfowler.com/articles/richardsonMaturityModel.html");
 		createNote("Hypertext Application Language (HAL)",
 				"http://stateless.co/hal_specification.html");
 		createNote("Application-Level Profile Semantics (ALPS)", "http://alps.io/spec/");
@@ -152,7 +152,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		this.mockMvc.perform(
@@ -180,7 +180,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		String noteLocation = this.mockMvc
@@ -240,7 +240,7 @@ public class ApiDocumentation {
 	public void noteUpdateExample() throws Exception {
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 
 		String noteLocation = this.mockMvc
 				.perform(

--- a/samples/rest-notes-spring-data-rest/src/main/asciidoc/getting-started-guide.adoc
+++ b/samples/rest-notes-spring-data-rest/src/main/asciidoc/getting-started-guide.adoc
@@ -20,7 +20,7 @@ to describe the relationships between resources and to allow navigation between 
 
 [getting-started-running-the-service]
 == Running the service
-RESTful Notes is written using http://projects.spring.io/spring-boot[Spring Boot] which
+RESTful Notes is written using https://projects.spring.io/spring-boot[Spring Boot] which
 makes it easy to get it up and running so that you can start exploring the REST API.
 
 The first step is to clone the Git repository:

--- a/samples/rest-notes-spring-data-rest/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-spring-data-rest/src/test/java/com/example/notes/ApiDocumentation.java
@@ -125,7 +125,7 @@ public class ApiDocumentation {
 		this.noteRepository.deleteAll();
 
 		createNote("REST maturity model",
-				"http://martinfowler.com/articles/richardsonMaturityModel.html");
+				"https://martinfowler.com/articles/richardsonMaturityModel.html");
 		createNote("Hypertext Application Language (HAL)",
 				"http://stateless.co/hal_specification.html");
 		createNote("Application-Level Profile Semantics (ALPS)", "http://alps.io/spec/");
@@ -155,7 +155,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		this.mockMvc.perform(
@@ -183,7 +183,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		String noteLocation = this.mockMvc
@@ -249,7 +249,7 @@ public class ApiDocumentation {
 	public void noteUpdateExample() throws Exception {
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 
 		String noteLocation = this.mockMvc
 				.perform(

--- a/samples/rest-notes-spring-hateoas/src/docs/asciidoc/getting-started-guide.adoc
+++ b/samples/rest-notes-spring-hateoas/src/docs/asciidoc/getting-started-guide.adoc
@@ -20,7 +20,7 @@ to describe the relationships between resources and to allow navigation between 
 
 [getting-started-running-the-service]
 == Running the service
-RESTful Notes is written using http://projects.spring.io/spring-boot[Spring Boot] which
+RESTful Notes is written using https://projects.spring.io/spring-boot[Spring Boot] which
 makes it easy to get it up and running so that you can start exploring the REST API.
 
 The first step is to clone the Git repository:

--- a/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java
+++ b/samples/rest-notes-spring-hateoas/src/test/java/com/example/notes/ApiDocumentation.java
@@ -147,7 +147,7 @@ public class ApiDocumentation {
 	public void notesListExample() throws Exception {
 		this.noteRepository.deleteAll();
 
-		createNote("REST maturity model", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		createNote("REST maturity model", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		createNote("Hypertext Application Language (HAL)", "http://stateless.co/hal_specification.html");
 		createNote("Application-Level Profile Semantics (ALPS)", "http://alps.io/spec/");
 		
@@ -173,7 +173,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		ConstrainedFields fields = new ConstrainedFields(NoteInput.class);
@@ -205,7 +205,7 @@ public class ApiDocumentation {
 
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 		note.put("tags", Arrays.asList(tagLocation));
 
 		String noteLocation = this.mockMvc
@@ -271,7 +271,7 @@ public class ApiDocumentation {
 	public void noteUpdateExample() throws Exception {
 		Map<String, Object> note = new HashMap<String, Object>();
 		note.put("title", "REST maturity model");
-		note.put("body", "http://martinfowler.com/articles/richardsonMaturityModel.html");
+		note.put("body", "https://martinfowler.com/articles/richardsonMaturityModel.html");
 
 		String noteLocation = this.mockMvc
 			.perform(post("/notes")

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HypermediaDocumentation.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HypermediaDocumentation.java
@@ -440,7 +440,7 @@ public abstract class HypermediaDocumentation {
 	 * {
 	 *     "_links": {
 	 *         "self": {
-	 *             "href": "http://example.com/foo"
+	 *             "href": "https://example.com/foo"
 	 *         }
 	 *     }
 	 * }
@@ -461,7 +461,7 @@ public abstract class HypermediaDocumentation {
 	 *     "links": [
 	 *         {
 	 *             "rel": "self",
-	 *             "href": "http://example.com/foo"
+	 *             "href": "https://example.com/foo"
 	 *         }
 	 *     ]
 	 * }

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/PrettyPrintingContentModifier.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/PrettyPrintingContentModifier.java
@@ -82,7 +82,7 @@ public class PrettyPrintingContentModifier implements ContentModifier {
 		public byte[] prettyPrint(byte[] original) throws Exception {
 			Transformer transformer = TransformerFactory.newInstance().newTransformer();
 			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount",
+			transformer.setOutputProperty("{https://xml.apache.org/xslt}indent-amount",
 					"4");
 			transformer.setOutputProperty(OutputKeys.DOCTYPE_PUBLIC, "yes");
 			ByteArrayOutputStream transformed = new ByteArrayOutputStream();

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsPayloadTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/LinkExtractorsPayloadTests.java
@@ -68,7 +68,7 @@ public class LinkExtractorsPayloadTests {
 	public void singleLink() throws IOException {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("single-link"));
-		assertLinks(Arrays.asList(new Link("alpha", "http://alpha.example.com", "Alpha")),
+		assertLinks(Arrays.asList(new Link("alpha", "https://alpha.example.com", "Alpha")),
 				links);
 	}
 
@@ -76,8 +76,8 @@ public class LinkExtractorsPayloadTests {
 	public void multipleLinksWithDifferentRels() throws IOException {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("multiple-links-different-rels"));
-		assertLinks(Arrays.asList(new Link("alpha", "http://alpha.example.com", "Alpha"),
-				new Link("bravo", "http://bravo.example.com")), links);
+		assertLinks(Arrays.asList(new Link("alpha", "https://alpha.example.com", "Alpha"),
+				new Link("bravo", "https://bravo.example.com")), links);
 	}
 
 	@Test
@@ -85,8 +85,8 @@ public class LinkExtractorsPayloadTests {
 		Map<String, List<Link>> links = this.linkExtractor
 				.extractLinks(createResponse("multiple-links-same-rels"));
 		assertLinks(Arrays.asList(
-				new Link("alpha", "http://alpha.example.com/one", "Alpha one"),
-				new Link("alpha", "http://alpha.example.com/two")), links);
+				new Link("alpha", "https://alpha.example.com/one", "Alpha one"),
+				new Link("alpha", "https://alpha.example.com/two")), links);
 	}
 
 	@Test

--- a/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-embedded-and-links.json
+++ b/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-embedded-and-links.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
-		"alpha": "http://alpha.example.com",
-		"bravo": "http://bravo.example.com"
+		"alpha": "https://alpha.example.com",
+		"bravo": "https://bravo.example.com"
 	},
 	"_embedded": "embedded-test",
 	"beta": "beta-value",

--- a/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-links.json
+++ b/spring-restdocs-core/src/test/resources/field-payloads/multiple-fields-and-links.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
-		"alpha": "http://alpha.example.com",
-		"bravo": "http://bravo.example.com"
+		"alpha": "https://alpha.example.com",
+		"bravo": "https://bravo.example.com"
 	},
 	"beta": "beta-value",
 	"charlie": "charlie-value"

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-different-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-different-rels.json
@@ -1,10 +1,10 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com",
+		"href": "https://alpha.example.com",
 		"title": "Alpha"
 	}, {
 		"rel": "bravo",
-		"href": "http://bravo.example.com"
+		"href": "https://bravo.example.com"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-same-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/multiple-links-same-rels.json
@@ -1,10 +1,10 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/one",
+		"href": "https://alpha.example.com/one",
 		"title": "Alpha one"
 	}, {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/two"
+		"href": "https://alpha.example.com/two"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/single-link.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/single-link.json
@@ -1,7 +1,7 @@
 {
 	"links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com",
+		"href": "https://alpha.example.com",
 		"title": "Alpha"
 	} ]
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/atom/wrong-format.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/atom/wrong-format.json
@@ -1,9 +1,9 @@
 {
 	"links": {
 		"alpha": [{
-		    "href": "http://alpha.example.com/one"
+		    "href": "https://alpha.example.com/one"
 		}, {
-		    "href": "http://alpha.example.com/two"
+		    "href": "https://alpha.example.com/two"
 		}]
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-different-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-different-rels.json
@@ -1,11 +1,11 @@
 {
 	"_links": {
 		"alpha": {
-			"href": "http://alpha.example.com",
+			"href": "https://alpha.example.com",
 			"title": "Alpha"
 		},
 		"bravo": {
-			"href": "http://bravo.example.com"
+			"href": "https://bravo.example.com"
 		}
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-same-rels.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/multiple-links-same-rels.json
@@ -1,10 +1,10 @@
 {
 	"_links": {
 		"alpha": [{
-		    "href": "http://alpha.example.com/one",
+		    "href": "https://alpha.example.com/one",
 			"title": "Alpha one"
 		}, {
-		    "href": "http://alpha.example.com/two"
+		    "href": "https://alpha.example.com/two"
 		}]
 	}
 }

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/single-link.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/single-link.json
@@ -1,7 +1,7 @@
 {
 	"_links": {
 		"alpha": {
-		    "href": "http://alpha.example.com",
+		    "href": "https://alpha.example.com",
 			"title": "Alpha"
 		}
 	}

--- a/spring-restdocs-core/src/test/resources/link-payloads/hal/wrong-format.json
+++ b/spring-restdocs-core/src/test/resources/link-payloads/hal/wrong-format.json
@@ -1,9 +1,9 @@
 {
 	"_links": [ {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/one"
+		"href": "https://alpha.example.com/one"
 	}, {
 		"rel": "alpha",
-		"href": "http://alpha.example.com/two"
+		"href": "https://alpha.example.com/two"
 	} ]
 }

--- a/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured/operation/preprocess/UriModifyingOperationPreprocessorTests.java
+++ b/spring-restdocs-restassured/src/test/java/org/springframework/restdocs/restassured/operation/preprocess/UriModifyingOperationPreprocessorTests.java
@@ -63,9 +63,9 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriHostCanBeModified() {
 		this.preprocessor.host("api.example.com");
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.foo.com:12345"));
+				.preprocess(createRequestWithUri("https://api.foo.com:12345"));
 		assertThat(processed.getUri(),
-				is(equalTo(URI.create("http://api.example.com:12345"))));
+				is(equalTo(URI.create("https://api.example.com:12345"))));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST),
 				is(equalTo("api.example.com:12345")));
 	}
@@ -74,9 +74,9 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPortCanBeModified() {
 		this.preprocessor.port(23456);
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345"));
 		assertThat(processed.getUri(),
-				is(equalTo(URI.create("http://api.example.com:23456"))));
+				is(equalTo(URI.create("https://api.example.com:23456"))));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST),
 				is(equalTo("api.example.com:23456")));
 	}
@@ -85,8 +85,8 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPortCanBeRemoved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345"));
-		assertThat(processed.getUri(), is(equalTo(URI.create("http://api.example.com"))));
+				.preprocess(createRequestWithUri("https://api.example.com:12345"));
+		assertThat(processed.getUri(), is(equalTo(URI.create("https://api.example.com"))));
 		assertThat(processed.getHeaders().getFirst(HttpHeaders.HOST),
 				is(equalTo("api.example.com")));
 	}
@@ -95,27 +95,27 @@ public class UriModifyingOperationPreprocessorTests {
 	public void requestUriPathIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345/foo/bar"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345/foo/bar"));
 		assertThat(processed.getUri(),
-				is(equalTo(URI.create("http://api.example.com/foo/bar"))));
+				is(equalTo(URI.create("https://api.example.com/foo/bar"))));
 	}
 
 	@Test
 	public void requestUriQueryIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345?foo=bar"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345?foo=bar"));
 		assertThat(processed.getUri(),
-				is(equalTo(URI.create("http://api.example.com?foo=bar"))));
+				is(equalTo(URI.create("https://api.example.com?foo=bar"))));
 	}
 
 	@Test
 	public void requestUriAnchorIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
-				.preprocess(createRequestWithUri("http://api.example.com:12345#foo"));
+				.preprocess(createRequestWithUri("https://api.example.com:12345#foo"));
 		assertThat(processed.getUri(),
-				is(equalTo(URI.create("http://api.example.com#foo"))));
+				is(equalTo(URI.create("https://api.example.com#foo"))));
 	}
 
 	@Test
@@ -135,7 +135,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createRequestWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getContent()),
-				is(equalTo("The uri 'http://api.example.com:12345' should be used")));
+				is(equalTo("The uri 'https://api.example.com:12345' should be used")));
 	}
 
 	@Test
@@ -215,7 +215,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createResponseWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getContent()),
-				is(equalTo("The uri 'http://api.example.com:12345' should be used")));
+				is(equalTo("The uri 'https://api.example.com:12345' should be used")));
 	}
 
 	@Test
@@ -283,7 +283,7 @@ public class UriModifyingOperationPreprocessorTests {
 		OperationRequest processed = this.preprocessor.host("api.example.com")
 				.preprocess(createRequestWithHeader("Foo", "http://locahost:12345"));
 		assertThat(processed.getHeaders().getFirst("Foo"),
-				is(equalTo("http://api.example.com:12345")));
+				is(equalTo("https://api.example.com:12345")));
 		assertThat(processed.getHeaders().getFirst("Host"),
 				is(equalTo("api.example.com")));
 	}
@@ -293,7 +293,7 @@ public class UriModifyingOperationPreprocessorTests {
 		OperationResponse processed = this.preprocessor.host("api.example.com")
 				.preprocess(createResponseWithHeader("Foo", "http://locahost:12345"));
 		assertThat(processed.getHeaders().getFirst("Foo"),
-				is(equalTo("http://api.example.com:12345")));
+				is(equalTo("https://api.example.com:12345")));
 	}
 
 	@Test
@@ -301,7 +301,7 @@ public class UriModifyingOperationPreprocessorTests {
 		OperationRequest processed = this.preprocessor.host("api.example.com").preprocess(
 				createRequestWithPartWithHeader("Foo", "http://locahost:12345"));
 		assertThat(processed.getParts().iterator().next().getHeaders().getFirst("Foo"),
-				is(equalTo("http://api.example.com:12345")));
+				is(equalTo("https://api.example.com:12345")));
 	}
 
 	@Test
@@ -310,7 +310,7 @@ public class UriModifyingOperationPreprocessorTests {
 				.preprocess(createRequestWithPartWithContent(
 						"The uri 'http://localhost:12345' should be used"));
 		assertThat(new String(processed.getParts().iterator().next().getContent()),
-				is(equalTo("The uri 'http://api.example.com:12345' should be used")));
+				is(equalTo("The uri 'https://api.example.com:12345' should be used")));
 	}
 
 	@Test


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://alps.io/spec/ (200) with 3 occurrences could not be migrated:  
   ([https](https://alps.io/spec/) result AnnotatedConnectException).
* [ ] http://benalman.com/news/2010/11/immediately-invoked-function-expression/ (200) with 1 occurrences could not be migrated:  
   ([https](https://benalman.com/news/2010/11/immediately-invoked-function-expression/) result NotSslRecordException).
* [ ] http://buddycloud.com/api (200) with 1 occurrences could not be migrated:  
   ([https](https://buddycloud.com/api) result SSLHandshakeException).
* [ ] http://paracel.io/docs/api_reference.html (200) with 1 occurrences could not be migrated:  
   ([https](https://paracel.io/docs/api_reference.html) result ClosedChannelException).
* [ ] http://rest-assured.io (200) with 1 occurrences could not be migrated:  
   ([https](https://rest-assured.io) result SSLHandshakeException).
* [ ] http://stateless.co/hal_specification.html (200) with 7 occurrences could not be migrated:  
   ([https](https://stateless.co/hal_specification.html) result SSLHandshakeException).
* [ ] http://www.gregfranko.com/jquery.tocify.js/ (301) with 1 occurrences could not be migrated:  
   ([https](https://www.gregfranko.com/jquery.tocify.js/) result SSLHandshakeException).
* [ ] http://www.rest-assured.io (301) with 2 occurrences could not be migrated:  
   ([https](https://www.rest-assured.io) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/ (301) with 2 occurrences migrated to:  
  https://johnresig.com/blog/ecmascript-5-strict-mode-json-and-more/ ([https](https://ejohn.org/blog/ecmascript-5-strict-mode-json-and-more/) result ClosedChannelException).
* [ ] http://api.foo.com:12345 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://api.foo.com:12345 ([https](https://api.foo.com:12345) result ConnectTimeoutException).
* [ ] http://alpha.example.com (UnknownHostException) with 8 occurrences migrated to:  
  https://alpha.example.com ([https](https://alpha.example.com) result UnknownHostException).
* [ ] http://alpha.example.com/one (UnknownHostException) with 5 occurrences migrated to:  
  https://alpha.example.com/one ([https](https://alpha.example.com/one) result UnknownHostException).
* [ ] http://alpha.example.com/two (UnknownHostException) with 5 occurrences migrated to:  
  https://alpha.example.com/two ([https](https://alpha.example.com/two) result UnknownHostException).
* [ ] http://api.example.com (UnknownHostException) with 2 occurrences migrated to:  
  https://api.example.com ([https](https://api.example.com) result UnknownHostException).
* [ ] http://api.example.com/foo/bar (UnknownHostException) with 1 occurrences migrated to:  
  https://api.example.com/foo/bar ([https](https://api.example.com/foo/bar) result UnknownHostException).
* [ ] http://api.example.com:12345 (UnknownHostException) with 10 occurrences migrated to:  
  https://api.example.com:12345 ([https](https://api.example.com:12345) result UnknownHostException).
* [ ] http://api.example.com:12345/foo/bar (UnknownHostException) with 1 occurrences migrated to:  
  https://api.example.com:12345/foo/bar ([https](https://api.example.com:12345/foo/bar) result UnknownHostException).
* [ ] http://api.example.com:12345?foo=bar (UnknownHostException) with 1 occurrences migrated to:  
  https://api.example.com:12345?foo=bar ([https](https://api.example.com:12345?foo=bar) result UnknownHostException).
* [ ] http://api.example.com:23456 (UnknownHostException) with 1 occurrences migrated to:  
  https://api.example.com:23456 ([https](https://api.example.com:23456) result UnknownHostException).
* [ ] http://api.example.com?foo=bar (UnknownHostException) with 1 occurrences migrated to:  
  https://api.example.com?foo=bar ([https](https://api.example.com?foo=bar) result UnknownHostException).
* [ ] http://bbc.bitrix.expert/ (UnknownHostException) with 1 occurrences migrated to:  
  https://bbc.bitrix.expert/ ([https](https://bbc.bitrix.expert/) result UnknownHostException).
* [ ] http://bravo.example.com (UnknownHostException) with 5 occurrences migrated to:  
  https://bravo.example.com ([https](https://bravo.example.com) result UnknownHostException).
* [ ] http://developer.golazon.com (UnknownHostException) with 1 occurrences migrated to:  
  https://developer.golazon.com ([https](https://developer.golazon.com) result UnknownHostException).
* [ ] http://rouge.jayferd.us/demo (UnknownHostException) with 1 occurrences migrated to:  
  https://rouge.jayferd.us/demo ([https](https://rouge.jayferd.us/demo) result UnknownHostException).
* [ ] http://tartaurs.org/~martin (UnknownHostException) with 1 occurrences migrated to:  
  https://tartaurs.org/~martin ([https](https://tartaurs.org/~martin) result UnknownHostException).
* [ ] http://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html (301) with 1 occurrences migrated to:  
  https://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html ([https](https://johannburkard.de/blog/programming/javascript/highlight-javascript-text-higlighting-jquery-plugin.html) result 403).
* [ ] http://appium.io/slate/en/master (404) with 1 occurrences migrated to:  
  https://appium.io/slate/en/master ([https](https://appium.io/slate/en/master) result 404).
* [ ] http://chaione.github.io/gameplanb2b/ (301) with 1 occurrences migrated to:  
  https://chaione.github.io/gameplanb2b/ ([https](https://chaione.github.io/gameplanb2b/) result 404).
* [ ] http://drcabana.github.io/build-a-quine/ (404) with 1 occurrences migrated to:  
  https://drcabana.github.io/build-a-quine/ ([https](https://drcabana.github.io/build-a-quine/) result 404).
* [ ] http://example.com/foo (404) with 2 occurrences migrated to:  
  https://example.com/foo ([https](https://example.com/foo) result 404).
* [ ] http://github.com/tripit/api/blob/master/source/index.md (301) with 1 occurrences migrated to:  
  https://github.com/tripit/api/blob/master/source/index.md ([https](https://github.com/tripit/api/blob/master/source/index.md) result 404).
* [ ] http://mozilla.github.io/localForage/ (301) with 1 occurrences migrated to:  
  https://mozilla.github.io/localForage/ ([https](https://mozilla.github.io/localForage/) result 404).
* [ ] http://tripit.github.io/slate (404) with 2 occurrences migrated to:  
  https://tripit.github.io/slate ([https](https://tripit.github.io/slate) result 404).
* [ ] http://xml.apache.org/xslt (404) with 1 occurrences migrated to:  
  https://xml.apache.org/xslt ([https](https://xml.apache.org/xslt) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://api.jqueryui.com/jQuery.widget/ with 1 occurrences migrated to:  
  https://api.jqueryui.com/jQuery.widget/ ([https](https://api.jqueryui.com/jQuery.widget/) result 200).
* [ ] http://apidocs.emergingthreats.net/ with 1 occurrences migrated to:  
  https://apidocs.emergingthreats.net/ ([https](https://apidocs.emergingthreats.net/) result 200).
* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/ with 2 occurrences migrated to:  
  https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/ ([https](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/) result 200).
* [ ] http://asciidoctor.org/docs/user-manual/ with 2 occurrences migrated to:  
  https://asciidoctor.org/docs/user-manual/ ([https](https://asciidoctor.org/docs/user-manual/) result 200).
* [ ] http://bugs.jquery.com/ticket/8235 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/8235 ([https](https://bugs.jquery.com/ticket/8235) result 200).
* [ ] http://bugs.jquery.com/ticket/9413 with 1 occurrences migrated to:  
  https://bugs.jquery.com/ticket/9413 ([https](https://bugs.jquery.com/ticket/9413) result 200).
* [ ] http://codestarframework.com/documentation/ with 1 occurrences migrated to:  
  https://codestarframework.com/documentation/ ([https](https://codestarframework.com/documentation/) result 200).
* [ ] http://curl.haxx.se with 1 occurrences migrated to:  
  https://curl.haxx.se ([https](https://curl.haxx.se) result 200).
* [ ] http://developer.aircall.io/ with 1 occurrences migrated to:  
  https://developer.aircall.io/ ([https](https://developer.aircall.io/) result 200).
* [ ] http://developer.marketprophit.com/ with 1 occurrences migrated to:  
  https://developer.marketprophit.com/ ([https](https://developer.marketprophit.com/) result 200).
* [ ] http://developer.viagogo.net/ with 1 occurrences migrated to:  
  https://developer.viagogo.net/ ([https](https://developer.viagogo.net/) result 200).
* [ ] http://docs.fidor.de/ with 1 occurrences migrated to:  
  https://docs.fidor.de/ ([https](https://docs.fidor.de/) result 200).
* [ ] http://docs.oauth.io/ with 1 occurrences migrated to:  
  https://docs.oauth.io/ ([https](https://docs.oauth.io/) result 200).
* [ ] http://docs.supportkit.io/ (301) with 1 occurrences migrated to:  
  https://docs.smooch.io/ ([https](https://docs.supportkit.io/) result 200).
* [ ] http://docs.travis-ci.com/api/ with 1 occurrences migrated to:  
  https://docs.travis-ci.com/api/ ([https](https://docs.travis-ci.com/api/) result 200).
* [ ] http://grails.org with 1 occurrences migrated to:  
  https://grails.org ([https](https://grails.org) result 200).
* [ ] http://httpie.org with 1 occurrences migrated to:  
  https://httpie.org ([https](https://httpie.org) result 200).
* [ ] http://jqueryui.com with 2 occurrences migrated to:  
  https://jqueryui.com ([https](https://jqueryui.com) result 200).
* [ ] http://logback.qos.ch/manual/groovy.html with 1 occurrences migrated to:  
  https://logback.qos.ch/manual/groovy.html ([https](https://logback.qos.ch/manual/groovy.html) result 200).
* [ ] http://lunrjs.com with 1 occurrences migrated to:  
  https://lunrjs.com ([https](https://lunrjs.com) result 200).
* [ ] http://martinfowler.com/articles/richardsonMaturityModel.html with 12 occurrences migrated to:  
  https://martinfowler.com/articles/richardsonMaturityModel.html ([https](https://martinfowler.com/articles/richardsonMaturityModel.html) result 200).
* [ ] http://mozilla.github.io/recroom/ with 1 occurrences migrated to:  
  https://mozilla.github.io/recroom/ ([https](https://mozilla.github.io/recroom/) result 200).
* [ ] http://projects.spring.io/spring-data-rest/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-data-rest/ ([https](https://projects.spring.io/spring-data-rest/) result 200).
* [ ] http://projects.spring.io/spring-hateoas/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-hateoas/ ([https](https://projects.spring.io/spring-hateoas/) result 200).
* [ ] http://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html with 1 occurrences migrated to:  
  https://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html ([https](https://ruby-doc.org/stdlib-2.2.3/libdoc/erb/rdoc/ERB.html) result 200).
* [ ] http://saucelabs.com with 1 occurrences migrated to:  
  https://saucelabs.com ([https](https://saucelabs.com) result 200).
* [ ] http://stackoverflow.com with 1 occurrences migrated to:  
  https://stackoverflow.com ([https](https://stackoverflow.com) result 200).
* [ ] http://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window ([https](https://stackoverflow.com/questions/2898740/iphone-safari-web-app-opens-links-in-new-window) result 200).
* [ ] http://switchpayments.com/developers/ with 1 occurrences migrated to:  
  https://switchpayments.com/developers/ ([https](https://switchpayments.com/developers/) result 200).
* [ ] http://switchpayments.com/docs/ with 1 occurrences migrated to:  
  https://switchpayments.com/docs/ ([https](https://switchpayments.com/docs/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 1 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://asciidoctor.org/docs/asciidoc-syntax-quick-reference with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/asciidoc-syntax-quick-reference ([https](https://asciidoctor.org/docs/asciidoc-syntax-quick-reference) result 301).
* [ ] http://asciidoctor.org/docs/user-manual with 1 occurrences migrated to:  
  https://asciidoctor.org/docs/user-manual ([https](https://asciidoctor.org/docs/user-manual) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle with 1 occurrences migrated to:  
  https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle ([https](https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle) result 301).
* [ ] http://fortawesome.github.io/Font-Awesome/ with 1 occurrences migrated to:  
  https://fortawesome.github.io/Font-Awesome/ ([https](https://fortawesome.github.io/Font-Awesome/) result 301).
* [ ] http://github.com/tripit/slate with 1 occurrences migrated to:  
  https://github.com/tripit/slate ([https](https://github.com/tripit/slate) result 301).
* [ ] http://jquery.org/license with 1 occurrences migrated to:  
  https://jquery.org/license ([https](https://jquery.org/license) result 301).
* [ ] http://projects.spring.io/spring-boot with 2 occurrences migrated to:  
  https://projects.spring.io/spring-boot ([https](https://projects.spring.io/spring-boot) result 301).
* [ ] http://tripit.com with 1 occurrences migrated to:  
  https://tripit.com ([https](https://tripit.com) result 301).
* [ ] http://tripit.github.io/api with 1 occurrences migrated to:  
  https://tripit.github.io/api ([https](https://tripit.github.io/api) result 301).
* [ ] http://w3.org/TR/2012/WD-url-20120524/ with 1 occurrences migrated to:  
  https://w3.org/TR/2012/WD-url-20120524/ ([https](https://w3.org/TR/2012/WD-url-20120524/) result 301).
* [ ] http://www.rozpisyzapasu.cz/dev/api/ with 1 occurrences migrated to:  
  https://www.rozpisyzapasu.cz/dev/api/ ([https](https://www.rozpisyzapasu.cz/dev/api/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle) result 302).
* [ ] http://tartarus.org/~martin/PorterStemmer/js.txt with 2 occurrences migrated to:  
  https://tartarus.org/~martin/PorterStemmer/js.txt ([https](https://tartarus.org/~martin/PorterStemmer/js.txt) result 302).

# Ignored
These URLs were intentionally ignored.

* http://locahost:12345 with 3 occurrences
* http://localhost with 79 occurrences
* http://localhost/ with 2 occurrences
* http://localhost/foo with 74 occurrences
* http://localhost/foo/bar with 3 occurrences
* http://localhost/foo?a=alpha with 15 occurrences
* http://localhost/foo?a=alpha&a=apple&b=br%26vo with 1 occurrences
* http://localhost/foo?a=alpha&b=bravo with 12 occurrences
* http://localhost/foo?b=bravo with 2 occurrences
* http://localhost/foo?b=bravo&a=alpha with 1 occurrences
* http://localhost/foo?bar with 1 occurrences
* http://localhost/foo?bar=baz with 1 occurrences
* http://localhost/foo?param with 8 occurrences
* http://localhost/foo?param=value with 12 occurrences
* http://localhost/upload with 20 occurrences
* http://localhost:12345 with 14 occurrences
* http://localhost:12345/foo/bar with 3 occurrences
* http://localhost:12345?foo=%7B%7D with 1 occurrences
* http://localhost:12345?foo=bar with 2 occurrences
* http://localhost:23456 with 2 occurrences
* http://localhost:4567 with 1 occurrences
* http://localhost:8080 with 2 occurrences
* http://localhost:8080/ with 2 occurrences
* http://localhost:8080/?a=alpha with 2 occurrences
* http://localhost:8080/?foo=bar with 2 occurrences
* http://localhost:8080/custom/ with 1 occurrences
* http://localhost:8080/foo with 2 occurrences
* http://localhost:8080/tags/123 with 3 occurrences
* http://localhost?a=al%26%3Dpha with 1 occurrences
* http://localhost?a=alpha with 1 occurrences
* http://localhost?a=alpha&b=bravo&c=charlie with 1 occurrences
* http://localhost?a=apple&a=avocado with 1 occurrences
* http://localhost?a=apple=avocado with 1 occurrences
* http://localhost?foo=bar with 2 occurrences
* http://testng.org with 1 occurrences