### PR TITLE
Fix trivial mistake made from last merge for `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ There are several that you can contribute to Spring REST Docs:
 
 | Name | Description |
 | ---- | ----------- |
-<<<<<<< HEAD
 | [restdocs-wiremock][17] | Auto-generate WireMock stubs as part of documenting your RESTful API |
 | [restdocsext-jersey][18] | Enables Spring REST Docs to be used with [Jersey's test framework][19] |
 | [spring-auto-restdocs][20] | Uses introspection and Javadoc to automatically document request and response parameters |


### PR DESCRIPTION
This trivial mistake was made [here](https://github.com/spring-projects/spring-restdocs/commit/6069d2864f881a5a03d18ef2637156bdc2c4c92c#diff-04c6e90faac2675aa89e2176d2eec7d8R40)
