### PR TITLE
Upgrade Asciidoctor Maven Plugin so that syntax highlighting can be enabled using an attribute

### DIFF
--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -111,7 +111,7 @@ the configuration are described in the following listings:
 			<plugin> <2>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
-				<version>1.5.3</version>
+				<version>1.5.8</version>
 				<executions>
 					<execution>
 						<id>generate-docs</id>

--- a/samples/rest-notes-spring-data-rest/pom.xml
+++ b/samples/rest-notes-spring-data-rest/pom.xml
@@ -72,7 +72,7 @@
 			<plugin>
 				<groupId>org.asciidoctor</groupId>
 				<artifactId>asciidoctor-maven-plugin</artifactId>
-				<version>1.5.3</version>
+				<version>1.5.8</version>
 				<executions>
 					<execution>
 						<id>generate-docs</id>


### PR DESCRIPTION
Unlike Gradle, when building with Maven plugin the `:source-highlighter: highlightjs` attribute in `*.adoc` files does not work (it can be even removed). You should explicitly specify `sourceHighlighter` in Maven plugin configuration, see https://asciidoctor.org/docs/asciidoctor-maven-plugin/#configuration-2