### PR TITLE
Fix IDs of sections in examples

### DIFF
--- a/samples/rest-notes-spring-data-rest/src/main/asciidoc/getting-started-guide.adoc
+++ b/samples/rest-notes-spring-data-rest/src/main/asciidoc/getting-started-guide.adoc
@@ -7,18 +7,18 @@ Andy Wilkinson;
 :toclevels: 4
 :sectlinks:
 
-[introduction]
+[[introduction]]
 = Introduction
 
 RESTful Notes is a RESTful web service for creating and storing notes. It uses hypermedia
 to describe the relationships between resources and to allow navigation between them.
 
-[getting-started]
+[[getting-started]]
 = Getting started
 
 
 
-[getting-started-running-the-service]
+[[getting-started-running-the-service]]
 == Running the service
 RESTful Notes is written using https://projects.spring.io/spring-boot[Spring Boot] which
 makes it easy to get it up and running so that you can start exploring the REST API.
@@ -54,7 +54,7 @@ Note the `_links` in the JSON response. They are key to navigating the API.
 
 
 
-[getting-started-creating-a-note]
+[[getting-started-creating-a-note]]
 == Creating a note
 Now that you've started the service and verified that it works, the next step is to use
 it to create a new note. As you saw above, the URI for working with notes is included as
@@ -85,7 +85,7 @@ Note the `tags` link which we'll make use of later.
 
 
 
-[getting-started-creating-a-tag]
+[[getting-started-creating-a-tag]]
 == Creating a tag
 To make a note easier to find, it can be associated with any number of tags. To be able
 to tag a note, you must first create the tag.
@@ -116,7 +116,7 @@ include::{snippets}/creating-a-note/4/http-response.adoc[]
 
 
 
-[getting-started-tagging-a-note]
+[[getting-started-tagging-a-note]]
 == Tagging a note
 A tag isn't particularly useful until it's been associated with one or more notes. There
 are two ways to tag a note: when the note is first created or by updating an existing
@@ -124,7 +124,7 @@ note. We'll look at both of these in turn.
 
 
 
-[getting-started-tagging-a-note-creating]
+[[getting-started-tagging-a-note-creating]]
 === Creating a tagged note
 The process is largely the same as we saw before, but this time, in addition to providing
 a title and body for the note, we'll also provide the tag that we want to be associated
@@ -155,7 +155,7 @@ include::{snippets}/creating-a-note/7/http-response.adoc[]
 
 
 
-[getting-started-tagging-a-note-existing]
+[[getting-started-tagging-a-note-existing]]
 === Tagging an existing note
 An existing note can be tagged by executing a `PATCH` request against the note's URI with
 a body that contains the array of tags to be associated with the note. We'll used the

--- a/samples/rest-notes-spring-hateoas/src/docs/asciidoc/getting-started-guide.adoc
+++ b/samples/rest-notes-spring-hateoas/src/docs/asciidoc/getting-started-guide.adoc
@@ -7,18 +7,18 @@ Andy Wilkinson;
 :toclevels: 4
 :sectlinks:
 
-[introduction]
+[[introduction]]
 = Introduction
 
 RESTful Notes is a RESTful web service for creating and storing notes. It uses hypermedia
 to describe the relationships between resources and to allow navigation between them.
 
-[getting-started]
+[[getting-started]]
 = Getting started
 
 
 
-[getting-started-running-the-service]
+[[getting-started-running-the-service]]
 == Running the service
 RESTful Notes is written using https://projects.spring.io/spring-boot[Spring Boot] which
 makes it easy to get it up and running so that you can start exploring the REST API.
@@ -52,7 +52,7 @@ Note the `_links` in the JSON response. They are key to navigating the API.
 
 
 
-[getting-started-creating-a-note]
+[[getting-started-creating-a-note]]
 == Creating a note
 Now that you've started the service and verified that it works, the next step is to use
 it to create a new note. As you saw above, the URI for working with notes is included as
@@ -83,7 +83,7 @@ Note the `note-tags` link which we'll make use of later.
 
 
 
-[getting-started-creating-a-tag]
+[[getting-started-creating-a-tag]]
 == Creating a tag
 To make a note easier to find, it can be associated with any number of tags. To be able
 to tag a note, you must first create the tag.
@@ -114,7 +114,7 @@ include::{snippets}/creating-a-note/4/http-response.adoc[]
 
 
 
-[getting-started-tagging-a-note]
+[[getting-started-tagging-a-note]]
 == Tagging a note
 A tag isn't particularly useful until it's been associated with one or more notes. There
 are two ways to tag a note: when the note is first created or by updating an existing
@@ -122,7 +122,7 @@ note. We'll look at both of these in turn.
 
 
 
-[getting-started-tagging-a-note-creating]
+[[getting-started-tagging-a-note-creating]]
 === Creating a tagged note
 The process is largely the same as we saw before, but this time, in addition to providing
 a title and body for the note, we'll also provide the tag that we want to be associated
@@ -153,7 +153,7 @@ include::{snippets}/creating-a-note/7/http-response.adoc[]
 
 
 
-[getting-started-tagging-a-note-existing]
+[[getting-started-tagging-a-note-existing]]
 === Tagging an existing note
 An existing note can be tagged by executing a `PATCH` request against the note's URI with
 a body that contains the array of tags to be associated with the note. We'll use the


### PR DESCRIPTION
In the examples the sections had their IDs in single brackets. 

This way they would be block attributes or block types. 

To set the ID for section, double brackets are necessary.

This PR fixes it.

(I found this as Asciidoctor 2.x versions complain about the block type)