### PR TITLE
Allow custom snippets directory via JUnit 5

### DIFF
--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -397,8 +397,8 @@ based on your project's build tool:
 
 |===
 
-The default can be overridden by providing an output directory when registering the
-`RestDocumentationExtension` instance:
+If you are using JUnit 5.1 or later the default can be overridden by providing
+an output directory when registering the `RestDocumentationExtension` instance:
 
 [source,java,indent=0]
 ----

--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -397,6 +397,18 @@ based on your project's build tool:
 
 |===
 
+The default can be overridden by providing an output directory when registering the
+`RestDocumentationExtension` instance:
+
+[source,java,indent=0]
+----
+public class JUnit5ExampleTests {
+    @RegisterExtension
+    static final RestDocumentationExtension restDocumentation =
+        new RestDocumentationExtension ("custom");
+}
+----
+
 
 
 Next, you must provide a `@BeforeEach` method to configure MockMvc, WebTestClient, or

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/RestDocumentationExtension.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/RestDocumentationExtension.java
@@ -33,6 +33,16 @@ import org.junit.jupiter.api.extension.ParameterResolver;
 public class RestDocumentationExtension
 		implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
+	private final String outputDirectory;
+
+	public RestDocumentationExtension () {
+		this(null);
+	}
+
+	public RestDocumentationExtension (String outputDirectory) {
+		this.outputDirectory = outputDirectory;
+	}
+
 	@Override
 	public void beforeEach(ExtensionContext context) throws Exception {
 		this.getDelegate(context).beforeTest(context.getRequiredTestClass(),
@@ -68,8 +78,15 @@ public class RestDocumentationExtension
 	private ManualRestDocumentation getDelegate(ExtensionContext context) {
 		Namespace namespace = Namespace.create(getClass(), context.getUniqueId());
 		return context.getStore(namespace).getOrComputeIfAbsent(
-				ManualRestDocumentation.class, (key) -> new ManualRestDocumentation(),
+				ManualRestDocumentation.class, this::createManualRestDocumentation,
 				ManualRestDocumentation.class);
 	}
 
+	private ManualRestDocumentation createManualRestDocumentation (Class<ManualRestDocumentation> key) {
+		if (outputDirectory != null) {
+			return new ManualRestDocumentation(outputDirectory);
+		} else {
+			return new ManualRestDocumentation();
+		}
+	}
 }


### PR DESCRIPTION
With these changes it is possible to specify a custom directory where the snippets are written to if you are using JUnit 5.