### PR TITLE
Section number incremented when it shouldn't

### DIFF
--- a/spring-restdocs-asciidoctor-support/src/main/resources/extensions/operation_block_macro.rb
+++ b/spring-restdocs-asciidoctor-support/src/main/resources/extensions/operation_block_macro.rb
@@ -48,9 +48,15 @@ class OperationBlockMacro < Asciidoctor::Extensions::BlockMacroProcessor
   def add_blocks(content, doc, parent)
     options = { safe: doc.options[:safe], attributes: doc.attributes }
     fragment = Asciidoctor.load content, options
+    # use a template to get the correct sectname and level for blocks to append
+    template = create_section(parent, '', {})
     fragment.blocks.each do |b|
       b.parent = parent
-      b.level += parent.level
+      # might be a standard block and no section in case of 'No snippets were found for operation'
+      if b.respond_to?(:sectname)
+        b.sectname = template.sectname
+      end
+      b.level = template.level
       parent << b
     end
     parent.find_by.each do |b|

--- a/spring-restdocs-asciidoctor/src/test/java/org/springframework/restdocs/asciidoctor/AbstractOperationBlockMacroTests.java
+++ b/spring-restdocs-asciidoctor/src/test/java/org/springframework/restdocs/asciidoctor/AbstractOperationBlockMacroTests.java
@@ -118,7 +118,7 @@ public abstract class AbstractOperationBlockMacroTests {
 	@Test
 	public void includeSnippetInSection() throws Exception {
 		String result = this.asciidoctor.convert(
-				"= A\n\nAlpha\n\n== B\n\nBravo\n\n" + "operation::some-operation[snippets='curl-request']",
+				"= A\n:doctype: book\n:sectnums:\n\nAlpha\n\n== B\n\nBravo\n\n" + "operation::some-operation[snippets='curl-request']\n\n== C\n",
 				this.options);
 		assertThat(result).isEqualTo(getExpectedContentFromFile("snippet-in-section"));
 	}

--- a/spring-restdocs-asciidoctor/src/test/resources/operations/snippet-in-section.html
+++ b/spring-restdocs-asciidoctor/src/test/resources/operations/snippet-in-section.html
@@ -6,18 +6,24 @@
 </div>
 </div>
 <div class="sect1">
-<h2 id="_b">B</h2>
+<h2 id="_b">1. B</h2>
 <div class="sectionbody">
 <div class="paragraph">
 <p>Bravo</p>
 </div>
 <div class="sect2">
-<h3 id="_b_curl_request">Curl request</h3>
+<h3 id="_b_curl_request">1.1. Curl request</h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlight"><code class="language-bash" data-lang="bash">$ curl 'http://localhost:8080/' -i</code></pre>
 </div>
 </div>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_c">2. C</h2>
+<div class="sectionbody">
+
 </div>
 </div>


### PR DESCRIPTION
My pull request for #628 introduced a regression: when using numbered sections using :sectnums: this produced gaps in the chapter number. 

I traced it down to the following issue: when the block is created, it is assigned a "sectname". For "==" this is "chapter", and it will increase the chapter number.

This change now sets level and sectname from a temporary template node. This leads to the correct sectname, and no chapter number will be increased. 

I see that #628 has been picked for the next maintenance release; maybe you want to revert/postpone it in the branch until this is taken care of.

I marked this [WIP] as it is missing a test.