### PR TITLE
Remove accidental characters in sample's pom.xml

### DIFF
--- a/samples/rest-notes-spring-data-rest/pom.xml
+++ b/samples/rest-notes-spring-data-rest/pom.xml
@@ -86,7 +86,7 @@
 							<logHandler>
 								<outputToConsole>true</outputToConsole>
 								<failIf>
-									<severity>DEBUG</severity> (2)
+									<severity>DEBUG</severity>
 								</failIf>
 							</logHandler>
 						</configuration>


### PR DESCRIPTION
This PR removes accidental characters in sample's `pom.xml` as it seems to be introduced accidentally.