### PR TITLE
Upgrade the Spring Boot-based samples to 2.1.9.RELEASE

### DIFF
--- a/samples/junit5/build.gradle
+++ b/samples/junit5/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.8.RELEASE'
+		classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.9.RELEASE'
 	}
 }
 

--- a/samples/rest-assured/build.gradle
+++ b/samples/rest-assured/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.8.RELEASE'
+		classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.9.RELEASE'
 	}
 }
 

--- a/samples/rest-notes-spring-data-rest/pom.xml
+++ b/samples/rest-notes-spring-data-rest/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.8.RELEASE</version>
+		<version>2.1.9.RELEASE</version>
 		<relativePath />
 	</parent>
 

--- a/samples/rest-notes-spring-hateoas/build.gradle
+++ b/samples/rest-notes-spring-hateoas/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.8.RELEASE'
+		classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.9.RELEASE'
 	}
 }
 

--- a/samples/testng/build.gradle
+++ b/samples/testng/build.gradle
@@ -3,7 +3,7 @@ buildscript {
 		mavenCentral()
 	}
 	dependencies {
-		classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.8.RELEASE'
+		classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.1.9.RELEASE'
 	}
 }
 


### PR DESCRIPTION
Spring Boot-based samples except `rest-notes-slate` seem to have been updated to 2.1.8.RELEASE in ce9d0c985f2183c81f3190255e080bcd75fa3b64. This PR changes to align Spring Boot versions across samples by upgrading the Spring Boot-based samples to 2.1.9.RELEASE.