### PR TITLE
Allow to easily configure custom ObjectMapper to preprocessors

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/CustomPrintingJsonContentModifier.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/CustomPrintingJsonContentModifier.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.operation.preprocess;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.springframework.http.MediaType;
+
+/**
+ * A {@link ContentModifier} that modifies the JSON content by custom printing it.
+ *
+ * @author Takaaki Iida
+ */
+public class CustomPrintingJsonContentModifier implements ContentModifier {
+
+	private final ObjectMapper objectMapper;
+
+	CustomPrintingJsonContentModifier(ObjectMapper objectMapper) {
+		this.objectMapper = objectMapper;
+	}
+
+	@Override
+	public byte[] modifyContent(byte[] originalContent, MediaType contentType) {
+		if (originalContent.length > 0) {
+			try {
+				return this.objectMapper.writeValueAsBytes(this.objectMapper.readTree(originalContent));
+			}
+			catch (Exception ex) {
+				// Continue
+			}
+		}
+
+		return originalContent;
+	}
+
+}

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/Preprocessors.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/Preprocessors.java
@@ -19,6 +19,8 @@ package org.springframework.restdocs.operation.preprocess;
 import java.util.Arrays;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.restdocs.operation.Operation;
 import org.springframework.restdocs.operation.OperationRequest;
 import org.springframework.restdocs.operation.OperationResponse;
@@ -65,6 +67,16 @@ public final class Preprocessors {
 	 */
 	public static OperationPreprocessor prettyPrint() {
 		return new ContentModifyingOperationPreprocessor(new PrettyPrintingContentModifier());
+	}
+
+	/**
+	 * Returns an {@code OperationPreprocessor} that will custom print the JSON content of
+	 * the request or response.
+	 * @param objectMapper the object mapper
+	 * @return the preprocessor
+	 */
+	public static OperationPreprocessor customJsonPrint(ObjectMapper objectMapper) {
+		return new ContentModifyingOperationPreprocessor(new CustomPrintingJsonContentModifier(objectMapper));
 	}
 
 	/**

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/operation/preprocess/CustomPrintingJsonContentModifierTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/operation/preprocess/CustomPrintingJsonContentModifierTests.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2014-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.restdocs.operation.preprocess;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link CustomPrintingJsonContentModifier}.
+ *
+ * @author Takaaki Iida
+ */
+public class CustomPrintingJsonContentModifierTests {
+
+	@Test
+	public void customPrint() throws Exception {
+		ObjectMapper objectMapper = new ObjectMapper().enable(JsonGenerator.Feature.WRITE_NUMBERS_AS_STRINGS);
+
+		assertThat(new CustomPrintingJsonContentModifier(objectMapper).modifyContent("{\"num\":123}".getBytes(), null))
+				.isEqualTo("{\"num\":\"123\"}".getBytes());
+	}
+
+	@Test
+	public void emptyContentIsHandledGracefully() throws Exception {
+		assertThat(new CustomPrintingJsonContentModifier(new ObjectMapper()).modifyContent("".getBytes(), null))
+				.isEqualTo("".getBytes());
+	}
+
+	@Test
+	public void nonJsonAndNonXmlContentIsHandledGracefully() throws Exception {
+		assertThat(new CustomPrintingJsonContentModifier(new ObjectMapper()).modifyContent("abcdefg".getBytes(), null))
+				.isEqualTo("abcdefg".getBytes());
+	}
+
+	@Test
+	public void encodingIsPreserved() throws Exception {
+		Map<String, String> input = new HashMap<>();
+		input.put("japanese", "\u30b3\u30f3\u30c6\u30f3\u30c4");
+		ObjectMapper objectMapper = new ObjectMapper();
+		@SuppressWarnings("unchecked")
+		Map<String, String> output = objectMapper.readValue(new CustomPrintingJsonContentModifier(objectMapper)
+				.modifyContent(objectMapper.writeValueAsBytes(input), null), Map.class);
+		assertThat(output).isEqualTo(input);
+	}
+
+}


### PR DESCRIPTION
I would like to configure custom `ObjectMapper` to preprocessors easily because `PrettyPrintingContentModifier` supports only indent output now.

```
private WebTestClient webTestClient;
private ObjectMapper objectMapper;

@Before
public void setup() {
	this.webTestClient = WebTestClient.bindToApplicationContext(this.context)
		.configureClient()
		.filter(documentationConfiguration(this.restDocumentation)
			.operationPreprocessors()
				.withRequestDefaults(removeHeaders("Foo")) 
				.withResponseDefaults(customJsonPrint(objectMapper)))   // here!!
		.build();
}
```