### PR TITLE
ignoreUndocumentedParamters is lost when using and() on PathParametersSnippet and RequestParametersSnippet

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/request/AbstractParametersSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/request/AbstractParametersSnippet.java
@@ -148,6 +148,10 @@ public abstract class AbstractParametersSnippet extends TemplatedSnippet {
 		return this.descriptorsByName;
 	}
 
+	protected final boolean isIgnoreUndocumentedParameters() {
+		return ignoreUndocumentedParameters;
+	}
+
 	/**
 	 * Returns a model for the given {@code descriptor}.
 	 * @param descriptor the descriptor

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/request/RequestParametersSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/request/RequestParametersSnippet.java
@@ -133,7 +133,7 @@ public class RequestParametersSnippet extends AbstractParametersSnippet {
 	public RequestParametersSnippet and(List<ParameterDescriptor> additionalDescriptors) {
 		List<ParameterDescriptor> combinedDescriptors = new ArrayList<>(getParameterDescriptors().values());
 		combinedDescriptors.addAll(additionalDescriptors);
-		return new RequestParametersSnippet(combinedDescriptors, this.getAttributes());
+		return new RequestParametersSnippet(combinedDescriptors, this.getAttributes(), this.isIgnoreUndocumentedParameters());
 	}
 
 }

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestParametersSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/request/RequestParametersSnippetTests.java
@@ -154,6 +154,15 @@ public class RequestParametersSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
+	public void additionalDescriptorsWithRelaxedRequestParameters() throws IOException {
+		RequestDocumentation.relaxedRequestParameters(parameterWithName("a").description("one"))
+				.and(parameterWithName("b").description("two")).document(this.operationBuilder
+						.request("http://localhost").param("a", "bravo").param("b", "bravo").param("c", "undocumented").build());
+		assertThat(this.generatedSnippets.requestParameters())
+				.is(tableWithHeader("Parameter", "Description").row("`a`", "one").row("`b`", "two"));
+	}
+
+	@Test
 	public void requestParametersWithEscapedContent() throws IOException {
 		RequestDocumentation.requestParameters(parameterWithName("Foo|Bar").description("one|two"))
 				.document(this.operationBuilder.request("http://localhost").param("Foo|Bar", "baz").build());


### PR DESCRIPTION
Hi, thanks for this project !

I noticed that using the `.and` method didin't propage the `ignoreUndocumentedParameters` flag resulting in exception raised at runtime. This PR fixes that by propagating the boolean flag.

```java
RequestDocumentation.relaxedRequestParameters(parameterWithName("a").description("one"))
				.and(parameterWithName("b").description("two"))
```