### PR TITLE
Warnings logged by the operation block macro lack context

### DIFF
--- a/spring-restdocs-asciidoctor/src/test/java/org/springframework/restdocs/asciidoctor/AbstractOperationBlockMacroTests.java
+++ b/spring-restdocs-asciidoctor/src/test/java/org/springframework/restdocs/asciidoctor/AbstractOperationBlockMacroTests.java
@@ -170,6 +170,11 @@ public abstract class AbstractOperationBlockMacroTests {
 	public void includingMissingSnippetAddsWarning() throws Exception {
 		String result = this.asciidoctor.convert("operation::some-operation[snippets='missing-snippet']", this.options);
 		assertThat(result).startsWith(getExpectedContentFromFile("missing-snippet"));
+		assertThat(CapturingLogHandler.getLogRecords()).hasSize(1);
+		assertThat(CapturingLogHandler.getLogRecords().get(0).getMessage())
+				.contains("Snippet missing-snippet not found");
+		assertThat(CapturingLogHandler.getLogRecords().get(0).getCursor().getLineNumber()).isEqualTo(1);
+		CapturingLogHandler.getLogRecords().clear();
 	}
 
 	@Test
@@ -182,6 +187,11 @@ public abstract class AbstractOperationBlockMacroTests {
 	public void missingOperationIsHandledGracefully() throws Exception {
 		String result = this.asciidoctor.convert("operation::missing-operation[]", this.options);
 		assertThat(result).startsWith(getExpectedContentFromFile("missing-operation"));
+		assertThat(CapturingLogHandler.getLogRecords()).hasSize(1);
+		assertThat(CapturingLogHandler.getLogRecords().get(0).getMessage())
+				.contains("No snippets were found for operation missing-operation");
+		assertThat(CapturingLogHandler.getLogRecords().get(0).getCursor().getLineNumber()).isEqualTo(1);
+		CapturingLogHandler.getLogRecords().clear();
 	}
 
 	@Test


### PR DESCRIPTION
I'm backporting a change that I applied in the IntelliJ AsciiDoc plugin to highlight problems with the operation macro in the editor. 

When using `logger.warn` with a cursor the output contains the file and line number where the problem occurred. 

The unit tests will log an example output like this (from a unit test)

```
WARNING: <stdin>: line 1: Snippet missing-snippet not found at C:\Users\...\AppData\Local\Temp\junit8239829976219138844\gradle-project\build\generated-snippets/some-operation/missing-snippet.adoc for operation some-operation
```