### PR TITLE
"included in the package" cross-reference is broken

### DIFF
--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -136,7 +136,7 @@ the configuration are described in the following listings:
 	`spring-restdocs-webtestclient` or `spring-restdocs-restassured` respectively instead.
 <2> Add the Asciidoctor plugin.
 <3> Using `prepare-package` allows the documentation to be
-	<<getting-started-build-configuration-maven-packaging, included in the package>>.
+	<<getting-started-build-configuration-packaging-the-documentation, included in the package>>.
 <4> Add `spring-restdocs-asciidoctor` as a dependency of the Asciidoctor plugin. This
 	will automatically configure the `snippets` attribute for use in your `.adoc` files to
 	point to `target/generated-snippets`. It will also allow you to use the `operation`


### PR DESCRIPTION
The anchor `getting-started-build-configuration-maven-packaging` is broken as it doesn't point an ID defined in one of the documents.
I tried to replace it from the context with `getting-started-build-configuration-packaging-the-documentation`. 

Please double-check if this is correct.