### PR TITLE
Fix bug when using beneath path and wildcard together

### DIFF
--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractorTests.java
@@ -132,6 +132,17 @@ public class FieldPathPayloadSubsectionExtractorTests {
 	}
 
 	@Test
+	public void extractSubSectionWithWildcardAndFieldDescriptors() throws IOException {
+		byte[] extractedPayload = new FieldPathPayloadSubsectionExtractor("*.d")
+				.extractSubsection("{\"a\":{\"b\":1},\"c\":{\"d\":{\"e\":1,\"f\":2}}}".getBytes(),
+								   MediaType.APPLICATION_JSON,
+								   Arrays.asList(new FieldDescriptor("e"), new FieldDescriptor("f")));
+		Map<String, Object> extracted = new ObjectMapper().readValue(extractedPayload, Map.class);
+		assertThat(extracted.size()).isEqualTo(2);
+		assertThat(extracted).containsOnlyKeys("e", "f");
+	}
+
+	@Test
 	public void extractedSubsectionIsPrettyPrintedWhenInputIsPrettyPrinted()
 			throws JsonParseException, JsonMappingException, JsonProcessingException, IOException {
 		ObjectMapper objectMapper = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
@@ -163,5 +174,4 @@ public class FieldPathPayloadSubsectionExtractorTests {
 						.isInstanceOf(PayloadHandlingException.class)
 						.hasMessage("a.c does not identify a section of the payload");
 	}
-
 }


### PR DESCRIPTION
Hi, I'm using restdocs so usefully 😀

I encountered following situation.

Here is the json body used in the request.
```json
{
   "number":"123",
   "link":{
      "scheme":"scheme",
      "url":"url"
   },
   "chat":{
      "message":"send message",
      "id":"id",
      "thread":{
         "content":"thread content",
         "count":1
      }
   }
}
```
And here is the test code using beneathPath and wildcard.
```kotlin
val messageRequest = MessageRequest(
        number = "123",
        link = Link("scheme", "url"),
        chat = Chat("send message", "id", Thread("thread content", 1)),
)
mockMvc.perform(
        RestDocumentationRequestBuilders.get("/test")
                .contentType(MediaType.APPLICATION_JSON)
                .content(objectMapper.writeValueAsBytes(messageRequest))
)
        .andExpect(status().isOk)
        .andDo(MockMvcRestDocumentation.document(
                "test",
                requestFields(
                        fieldWithPath("number").type(JsonFieldType.STRING).description("a"),
                        subsectionWithPath("link").type(JsonFieldType.OBJECT).description("z"),
                        subsectionWithPath("chat").type(JsonFieldType.OBJECT).description("f"),
                ),
                requestFields(
                        beneathPath("*.thread").withSubsectionId("thread"),
                        fieldWithPath("content").type(JsonFieldType.STRING).description("thread message").optional(),
                        fieldWithPath("count").type(JsonFieldType.NUMBER).description("count").optional(),
                ),
        ))
```
And I saw error like below.
```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class java.lang.Object and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)
```
This is because using wildcards will result in unmatched-pattern object field `link` being `Extracted Field.Absent`. `Extracted Field.Absent` is assigned to `Object()`, so serialization fail.
So I filter non-absent field.