### PR TITLE
Add missing json() invocation in JsonFieldPathsTests

### DIFF
--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathsTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/JsonFieldPathsTests.java
@@ -80,7 +80,7 @@ public class JsonFieldPathsTests {
 	public void absentItemFromFieldExtractionCausesAllPresentFieldsToBeIdentifiedAsUncommon() {
 		assertThat(
 				JsonFieldPaths
-						.from(Arrays.asList(ExtractedField.ABSENT, ("{\"a\": 1, \"b\": {\"c\": 1}}"),
+						.from(Arrays.asList(ExtractedField.ABSENT, json("{\"a\": 1, \"b\": {\"c\": 1}}"),
 								json("{\"a\": 1, \"b\": {\"c\": 1}}"), json("{\"a\": 1, \"b\": {\"d\": 2}}")))
 						.getUncommon()).containsExactly("", "a", "b", "b.c", "b.d");
 	}


### PR DESCRIPTION
This PR adds a `json()` invocation in `JsonFieldPathsTests.absentItemFromFieldExtractionCausesAllPresentFieldsToBeIdentifiedAsUncommon()` that seems to be missed accidentally in 2b5eab309ce53098235bace0e52a9331284ad2f9.