### PR TITLE
Remove redundant public modifiers for Groovy

### DIFF
--- a/buildSrc/src/main/groovy/org/springframework/restdocs/build/matrix/MatrixTestExtension.groovy
+++ b/buildSrc/src/main/groovy/org/springframework/restdocs/build/matrix/MatrixTestExtension.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.Task
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.tasks.testing.Test
 
-public class MatrixTestExtension {
+class MatrixTestExtension {
 
 	private List<Entry> entries = []
 

--- a/buildSrc/src/main/groovy/org/springframework/restdocs/build/matrix/MatrixTestPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/springframework/restdocs/build/matrix/MatrixTestPlugin.groovy
@@ -19,9 +19,9 @@ package org.springframework.restdocs.build.matrix
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-public class MatrixTestPlugin implements Plugin<Project> {
+class MatrixTestPlugin implements Plugin<Project> {
 
-	public void apply(Project project) {
+	void apply(Project project) {
 		project.extensions.create('matrixTest', MatrixTestExtension, project)
 	}
 

--- a/buildSrc/src/main/groovy/org/springframework/restdocs/build/samples/SampleBuildConfigurer.groovy
+++ b/buildSrc/src/main/groovy/org/springframework/restdocs/build/samples/SampleBuildConfigurer.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.GradleBuild
 
-public class SampleBuildConfigurer {
+class SampleBuildConfigurer {
 
 	private final String name
 

--- a/buildSrc/src/main/groovy/org/springframework/restdocs/build/samples/SamplesExtension.groovy
+++ b/buildSrc/src/main/groovy/org/springframework/restdocs/build/samples/SamplesExtension.groovy
@@ -19,7 +19,7 @@ package org.springframework.restdocs.build.samples
 import org.gradle.api.Project
 import org.gradle.api.Task
 
-public class SamplesExtension {
+class SamplesExtension {
 
 	Project Project
 

--- a/buildSrc/src/main/groovy/org/springframework/restdocs/build/samples/SamplesPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/springframework/restdocs/build/samples/SamplesPlugin.groovy
@@ -19,9 +19,9 @@ package org.springframework.restdocs.build.samples
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-public class SamplesPlugin implements Plugin<Project> {
+class SamplesPlugin implements Plugin<Project> {
 
-	public void apply(Project project) {
+	void apply(Project project) {
 		def buildSamplesTask = project.tasks.create('buildSamples')
 		buildSamplesTask.description = 'Builds the configured samples'
 		buildSamplesTask.group = 'Build'


### PR DESCRIPTION
This PR removes redundant `public` modifiers for Groovy.

See https://groovy-lang.org/style-guide.html#_public_by_default