### PR TITLE
Unhelpful IndexOutOfBoundException when an empty array subsection is extracted

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractor.java
@@ -92,6 +92,9 @@ public class FieldPathPayloadSubsectionExtractor
 							this::prependFieldPath));
 			if (value instanceof List) {
 				List<?> extractedList = (List<?>) value;
+				if (extractedList.isEmpty()) {
+					throw new PayloadHandlingException(this.fieldPath + " identifies a section of payload, but the section is empty");
+				}
 				JsonContentHandler contentHandler = new JsonContentHandler(payload, descriptorsByPath.values());
 				Set<JsonFieldPath> uncommonPaths = JsonFieldPaths.from(extractedList).getUncommon().stream()
 						.map((path) -> JsonFieldPath

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/FieldPathPayloadSubsectionExtractorTests.java
@@ -183,4 +183,12 @@ public class FieldPathPayloadSubsectionExtractorTests {
 						.hasMessage("a.c does not identify a section of the payload");
 	}
 
+	@Test
+	public void extractEmptySubsection() throws JsonParseException, JsonMappingException, IOException {
+		assertThatThrownBy(() -> new FieldPathPayloadSubsectionExtractor("a")
+				.extractSubsection("{\"a\":[]}}".getBytes(), MediaType.APPLICATION_JSON))
+				.isInstanceOf(PayloadHandlingException.class)
+				.hasMessage("a identifies a section of payload, but the section is empty");
+	}
+
 }


### PR DESCRIPTION
When I try to extract subsection `a` from payload with `{"a" : []}`, `IndexOutOfBoundsException` occurs . User-friendly messages are required.