### PR TITLE
Upgrade to Spring Java Format 0.0.33

### DIFF
--- a/.springjavaformatconfig
+++ b/.springjavaformatconfig
@@ -1,0 +1,1 @@
+java-baseline=8

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -4,4 +4,5 @@
 		"https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
 	<suppress files="com[\\/]example[\\/]restassured" checks="IllegalImport" />
+	<suppress files="src[\\/]testFixtures" checks="JavadocPackage" />
 </suppressions>

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,5 +13,5 @@ asciidoctorj23Version=2.3.0
 asciidoctorj24Version=2.4.3
 asciidoctorj25Version=2.5.1
 
-javaFormatVersion=0.0.29
+javaFormatVersion=0.0.33
 jmustacheVersion=1.12

--- a/spring-restdocs-asciidoctor-1.5/src/main/java/org/springframework/restdocs/asciidoctor/package-info.java
+++ b/spring-restdocs-asciidoctor-1.5/src/main/java/org/springframework/restdocs/asciidoctor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for Asciidoctor.
+ */
+package org.springframework.restdocs.asciidoctor;

--- a/spring-restdocs-asciidoctor-1.6/src/main/java/org/springframework/restdocs/asciidoctor/package-info.java
+++ b/spring-restdocs-asciidoctor-1.6/src/main/java/org/springframework/restdocs/asciidoctor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for Asciidoctor.
+ */
+package org.springframework.restdocs.asciidoctor;

--- a/spring-restdocs-asciidoctor-2.x/src/main/java/org/springframework/restdocs/asciidoctor/package-info.java
+++ b/spring-restdocs-asciidoctor-2.x/src/main/java/org/springframework/restdocs/asciidoctor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for Asciidoctor.
+ */
+package org.springframework.restdocs.asciidoctor;

--- a/spring-restdocs-asciidoctor-support/src/main/java/org/springframework/restdocs/asciidoctor/package-info.java
+++ b/spring-restdocs-asciidoctor-support/src/main/java/org/springframework/restdocs/asciidoctor/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Support for Asciidoctor.
+ */
+package org.springframework.restdocs.asciidoctor;


### PR DESCRIPTION
This PR upgrades to Spring Java Format 0.0.33.

This PR also adds missing `package-info.java` files.