### PR TITLE
Use HTTPS for REST Assured links

### DIFF
--- a/config/nohttp/allowlist.lines
+++ b/config/nohttp/allowlist.lines
@@ -1,1 +1,0 @@
-^http://rest-assured.io.*

--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -42,7 +42,7 @@ If you want to jump straight in, a number of sample applications are available:
 
 | {samples}/rest-assured[REST Assured]
 | Gradle
-| Demonstrates the use of Spring REST Docs with http://rest-assured.io[REST Assured].
+| Demonstrates the use of Spring REST Docs with https://rest-assured.io/[REST Assured].
 |===
 
 
@@ -247,7 +247,7 @@ The following listings show how to do so in both Maven and Gradle:
 [[getting-started-documentation-snippets]]
 === Generating Documentation Snippets
 
-Spring REST Docs uses Spring MVC's {spring-framework-docs}/testing.html#spring-mvc-test-framework[test framework], Spring WebFlux's {spring-framework-docs}/testing.html#webtestclient[`WebTestClient`], or http://rest-assured.io/[REST Assured] to make requests to the service that you are documenting.
+Spring REST Docs uses Spring MVC's {spring-framework-docs}/testing.html#spring-mvc-test-framework[test framework], Spring WebFlux's {spring-framework-docs}/testing.html#webtestclient[`WebTestClient`], or https://rest-assured.io/[REST Assured] to make requests to the service that you are documenting.
 It then produces documentation snippets for the request and the resulting response.
 
 

--- a/docs/src/docs/asciidoc/introduction.adoc
+++ b/docs/src/docs/asciidoc/introduction.adoc
@@ -9,7 +9,7 @@ To this end, Spring REST Docs uses https://asciidoctor.org[Asciidoctor] by defau
 Asciidoctor processes plain text and produces HTML, styled and laid out to suit your needs.
 If you prefer, you can also configure Spring REST Docs to use Markdown.
 
-Spring REST Docs uses snippets produced by tests written with Spring MVC's {spring-framework-docs}/testing.html#spring-mvc-test-framework[test framework], Spring WebFlux's {spring-framework-docs}/testing.html#webtestclient[`WebTestClient`] or http://rest-assured.io[REST Assured 3].
+Spring REST Docs uses snippets produced by tests written with Spring MVC's {spring-framework-docs}/testing.html#spring-mvc-test-framework[test framework], Spring WebFlux's {spring-framework-docs}/testing.html#webtestclient[`WebTestClient`] or https://rest-assured.io/[REST Assured 3].
 This test-driven approach helps to guarantee the accuracy of your service's documentation.
 If a snippet is incorrect, the test that produces it fails.
 


### PR DESCRIPTION
This PR changes to use HTTPS for REST Assured links.

This PR also drops unnecessary `nohttp` `allowlist.lines` file.