### PR TITLE
Suppress deprecation warnings in RestDocumentationRequestBuildersTests

### DIFF
--- a/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/RestDocumentationRequestBuildersTests.java
+++ b/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/RestDocumentationRequestBuildersTests.java
@@ -129,11 +129,13 @@ public class RestDocumentationRequestBuildersTests {
 		assertUri(request(HttpMethod.GET, URI.create("/uri")), HttpMethod.GET);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void fileUploadTemplate() {
 		assertTemplate(fileUpload("/{template}", "t"), HttpMethod.POST);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void fileUploadUri() {
 		assertUri(fileUpload(URI.create("/uri")), HttpMethod.POST);


### PR DESCRIPTION
This PR suppresses deprecation warnings in `RestDocumentationRequestBuildersTests`.