### PR TITLE
Avoid substring creation when writing a portion of a string to a StringBuilder

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
@@ -213,7 +213,7 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 			while (matcher.find()) {
 				for (int i = 1; i <= matcher.groupCount(); i++) {
 					if (matcher.start(i) >= 0) {
-						builder.append(input.substring(previous, matcher.start(i)));
+						builder.append(input, previous, matcher.start(i));
 					}
 					if (matcher.start(i) >= 0) {
 						previous = matcher.end(i);


### PR DESCRIPTION
This PR refactors the 'modify' method by replacing duplicate substring code with a single call to 'append'. This change enhances code readability and maintainability.

Please review and merge this PR. Thank you!