### PR TITLE
Revert "Fix compatibility problems with Spring Framework 6.2"

### DIFF
--- a/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/RestDocumentationRequestBuilders.java
+++ b/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/RestDocumentationRequestBuilders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,8 +51,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 * @return the builder for the GET request
 	 */
 	public static MockHttpServletRequestBuilder get(String urlTemplate, Object... urlVariables) {
-		return (MockHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.get(urlTemplate, urlVariables), urlTemplate);
+		return MockMvcRequestBuilders.get(urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -72,8 +72,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 * @return the builder for the POST request
 	 */
 	public static MockHttpServletRequestBuilder post(String urlTemplate, Object... urlVariables) {
-		return (MockHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.post(urlTemplate, urlVariables), urlTemplate);
+		return MockMvcRequestBuilders.post(urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -93,8 +93,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 * @return the builder for the PUT request
 	 */
 	public static MockHttpServletRequestBuilder put(String urlTemplate, Object... urlVariables) {
-		return (MockHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.put(urlTemplate, urlVariables), urlTemplate);
+		return MockMvcRequestBuilders.put(urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -114,8 +114,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 * @return the builder for the PATCH request
 	 */
 	public static MockHttpServletRequestBuilder patch(String urlTemplate, Object... urlVariables) {
-		return (MockHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.patch(urlTemplate, urlVariables), urlTemplate);
+		return MockMvcRequestBuilders.patch(urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -135,8 +135,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 * @return the builder for the DELETE request
 	 */
 	public static MockHttpServletRequestBuilder delete(String urlTemplate, Object... urlVariables) {
-		return (MockHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.delete(urlTemplate, urlVariables), urlTemplate);
+		return MockMvcRequestBuilders.delete(urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -156,8 +156,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 * @return the builder for the OPTIONS request
 	 */
 	public static MockHttpServletRequestBuilder options(String urlTemplate, Object... urlVariables) {
-		return (MockHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.options(urlTemplate, urlVariables), urlTemplate);
+		return MockMvcRequestBuilders.options(urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -177,8 +177,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 * @return the builder for the HEAD request
 	 */
 	public static MockHttpServletRequestBuilder head(String urlTemplate, Object... urlVariables) {
-		return (MockHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.head(urlTemplate, urlVariables), urlTemplate);
+		return MockMvcRequestBuilders.head(urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -200,8 +200,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 */
 	public static MockHttpServletRequestBuilder request(HttpMethod httpMethod, String urlTemplate,
 			Object... urlVariables) {
-		return (MockHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.request(httpMethod, urlTemplate, urlVariables), urlTemplate);
+		return MockMvcRequestBuilders.request(httpMethod, urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -224,8 +224,8 @@ public abstract class RestDocumentationRequestBuilders {
 	 * @since 2.0.6
 	 */
 	public static MockMultipartHttpServletRequestBuilder multipart(String urlTemplate, Object... urlVariables) {
-		return (MockMultipartHttpServletRequestBuilder) configureUrlTemplateRequestAttribute(
-				MockMvcRequestBuilders.multipart(urlTemplate, urlVariables), urlTemplate);
+		return (MockMultipartHttpServletRequestBuilder) MockMvcRequestBuilders.multipart(urlTemplate, urlVariables)
+			.requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
 	}
 
 	/**
@@ -236,17 +236,6 @@ public abstract class RestDocumentationRequestBuilders {
 	 */
 	public static MockMultipartHttpServletRequestBuilder multipart(URI uri) {
 		return MockMvcRequestBuilders.multipart(uri);
-	}
-
-	private static Object configureUrlTemplateRequestAttribute(Object builder, String urlTemplate) {
-		try {
-			return builder.getClass()
-				.getMethod("requestAttr", String.class, Object.class)
-				.invoke(builder, RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
-		}
-		catch (Exception ex) {
-			throw new RuntimeException(ex);
-		}
 	}
 
 }

--- a/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcRequestConverterTests.java
+++ b/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/MockMvcRequestConverterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import org.springframework.restdocs.operation.OperationRequest;
 import org.springframework.restdocs.operation.OperationRequestPart;
 import org.springframework.restdocs.operation.RequestCookie;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -234,10 +233,6 @@ public class MockMvcRequestConverterTests {
 	}
 
 	private OperationRequest createOperationRequest(MockHttpServletRequestBuilder builder) {
-		return this.factory.convert(builder.buildRequest(new MockServletContext()));
-	}
-
-	private OperationRequest createOperationRequest(MockMultipartHttpServletRequestBuilder builder) {
 		return this.factory.convert(builder.buildRequest(new MockServletContext()));
 	}
 

--- a/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/RestDocumentationRequestBuildersTests.java
+++ b/spring-restdocs-mockmvc/src/test/java/org/springframework/restdocs/mockmvc/RestDocumentationRequestBuildersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
 import org.springframework.restdocs.generate.RestDocumentationGenerator;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -141,15 +140,6 @@ public class RestDocumentationRequestBuildersTests {
 
 	private void assertTemplate(MockHttpServletRequestBuilder builder, HttpMethod httpMethod) {
 		MockHttpServletRequest request = builder.buildRequest(this.servletContext);
-		assertTemplate(httpMethod, request);
-	}
-
-	private void assertTemplate(MockMultipartHttpServletRequestBuilder builder, HttpMethod httpMethod) {
-		MockHttpServletRequest request = builder.buildRequest(this.servletContext);
-		assertTemplate(httpMethod, request);
-	}
-
-	private void assertTemplate(HttpMethod httpMethod, MockHttpServletRequest request) {
 		assertThat((String) request.getAttribute(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE))
 			.isEqualTo("/{template}");
 		assertThat(request.getRequestURI()).isEqualTo("/t");
@@ -158,15 +148,6 @@ public class RestDocumentationRequestBuildersTests {
 
 	private void assertUri(MockHttpServletRequestBuilder builder, HttpMethod httpMethod) {
 		MockHttpServletRequest request = builder.buildRequest(this.servletContext);
-		assertUri(httpMethod, request);
-	}
-
-	private void assertUri(MockMultipartHttpServletRequestBuilder builder, HttpMethod httpMethod) {
-		MockHttpServletRequest request = builder.buildRequest(this.servletContext);
-		assertUri(httpMethod, request);
-	}
-
-	private void assertUri(HttpMethod httpMethod, MockHttpServletRequest request) {
 		assertThat(request.getRequestURI()).isEqualTo("/uri");
 		assertThat(request.getMethod()).isEqualTo(httpMethod.name());
 	}


### PR DESCRIPTION
This commit reverts most of cf451c9 as the underlying problem that it fixed is no longer applicable.

See https://github.com/spring-projects/spring-framework/issues/33229