### PR TITLE
#942 Omit the version in the Maven Resources plugin example

### DIFF
--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -146,7 +146,6 @@ The following listings show how to do so in both Maven and Gradle:
 	</plugin>
 	<plugin> <2>
 		<artifactId>maven-resources-plugin</artifactId>
-		<version>2.7</version>
 		<executions>
 			<execution>
 				<id>copy-resources</id>


### PR DESCRIPTION
Fix for #942 