### PR TITLE
When a request contains multiple cookies, HTTP request snippet has multiple Cookie headers when the spec permits only one

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
@@ -103,8 +103,12 @@ public class HttpRequestSnippet extends TemplatedSnippet {
 			}
 		}
 
+		List<String> cookies = new ArrayList<>();
 		for (RequestCookie cookie : request.getCookies()) {
-			headers.add(header(HttpHeaders.COOKIE, String.format("%s=%s", cookie.getName(), cookie.getValue())));
+			cookies.add(String.format("%s=%s", cookie.getName(), cookie.getValue()));
+		}
+		if (!cookies.isEmpty()) {
+			headers.add(header(HttpHeaders.COOKIE, String.join("; ", cookies)));
 		}
 
 		if (requiresFormEncodingContentTypeHeader(request)) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/http/HttpRequestSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/http/HttpRequestSnippetTests.java
@@ -82,8 +82,7 @@ public class HttpRequestSnippetTests extends AbstractSnippetTests {
 			.build());
 		assertThat(this.generatedSnippets.httpRequest())
 			.is(httpRequest(RequestMethod.GET, "/foo").header(HttpHeaders.HOST, "localhost")
-				.header(HttpHeaders.COOKIE, "name1=value1")
-				.header(HttpHeaders.COOKIE, "name2=value2"));
+				.header(HttpHeaders.COOKIE, "name1=value1; name2=value2"));
 	}
 
 	@Test


### PR DESCRIPTION
This PR changes to use a single `Cookie` header in the `HttpRequestSnippet` to align with the following in RFC 6265:

> When the user agent generates an HTTP request, the user agent MUST NOT attach more than one Cookie header field.

See https://www.rfc-editor.org/rfc/rfc6265#section-5.4