### PR TITLE
Correct typo from 'Explict' to 'Explicit'

### DIFF
--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/RequestFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/RequestFieldsSnippetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/RequestFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/RequestFieldsSnippetTests.java
@@ -44,6 +44,7 @@ import static org.springframework.restdocs.snippet.Attributes.key;
  * Tests for {@link RequestFieldsSnippet}.
  *
  * @author Andy Wilkinson
+ * @author Sungjun Lee
  */
 public class RequestFieldsSnippetTests extends AbstractSnippetTests {
 
@@ -239,7 +240,7 @@ public class RequestFieldsSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
-	public void fieldWithExplictExactlyMatchingType() throws IOException {
+	public void fieldWithExplicitExactlyMatchingType() throws IOException {
 		new RequestFieldsSnippet(Arrays.asList(fieldWithPath("a").description("one").type(JsonFieldType.NUMBER)))
 			.document(this.operationBuilder.request("http://localhost").content("{\"a\": 5 }").build());
 		assertThat(this.generatedSnippets.requestFields())
@@ -247,7 +248,7 @@ public class RequestFieldsSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
-	public void fieldWithExplictVariesType() throws IOException {
+	public void fieldWithExplicitVariesType() throws IOException {
 		new RequestFieldsSnippet(Arrays.asList(fieldWithPath("a").description("one").type(JsonFieldType.VARIES)))
 			.document(this.operationBuilder.request("http://localhost").content("{\"a\": 5 }").build());
 		assertThat(this.generatedSnippets.requestFields())

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/payload/ResponseFieldsSnippetTests.java
@@ -43,6 +43,7 @@ import static org.springframework.restdocs.snippet.Attributes.key;
  * Tests for {@link ResponseFieldsSnippet}.
  *
  * @author Andy Wilkinson
+ * @author Sungjun Lee
  */
 public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 
@@ -224,7 +225,7 @@ public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
-	public void fieldWithExplictExactlyMatchingType() throws IOException {
+	public void fieldWithExplicitExactlyMatchingType() throws IOException {
 		new ResponseFieldsSnippet(Arrays.asList(fieldWithPath("a").description("one").type(JsonFieldType.NUMBER)))
 			.document(this.operationBuilder.response().content("{\"a\": 5 }").build());
 		assertThat(this.generatedSnippets.responseFields())
@@ -232,7 +233,7 @@ public class ResponseFieldsSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
-	public void fieldWithExplictVariesType() throws IOException {
+	public void fieldWithExplicitVariesType() throws IOException {
 		new ResponseFieldsSnippet(Arrays.asList(fieldWithPath("a").description("one").type(JsonFieldType.VARIES)))
 			.document(this.operationBuilder.response().content("{\"a\": 5 }").build());
 		assertThat(this.generatedSnippets.responseFields())


### PR DESCRIPTION
Correct typo from 'Explict' to 'Explicit'.