### PR TITLE
Add support for URI's path prefix modification

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
@@ -228,14 +228,15 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 		private String modify(String input) {
 			List<String> replacements = Arrays.asList(this.scheme, this.host,
 					StringUtils.hasText(this.port) ? ":" + this.port : this.port,
-					this.pathPrefix);
+					this.pathPrefix == null ? "" : this.pathPrefix.startsWith("/") ? this.pathPrefix : "/" + this.pathPrefix);
 
 			int previous = 0;
 
 			Matcher matcher = SCHEME_HOST_PORT_PATTERN.matcher(input);
 			StringBuilder builder = new StringBuilder();
 			while (matcher.find()) {
-				for (int i = 1; i <= matcher.groupCount(); i++) {
+				int matcherGroupCount = matcher.groupCount();
+				for (int i = 1; i <= matcherGroupCount; i++) {
 					if (matcher.start(i) >= 0) {
 						builder.append(input, previous, matcher.start(i));
 					}
@@ -243,6 +244,9 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 						previous = matcher.end(i);
 					}
 					builder.append(getReplacement(matcher.group(i), replacements.get(i - 1)));
+					if (i == matcherGroupCount) {
+						builder.append(replacements.get(i));
+					}
 				}
 			}
 

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
@@ -66,6 +66,8 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 
 	private String port;
 
+	private String pathPrefix;
+
 	/**
 	 * Modifies the URI to use the given {@code scheme}. {@code null}, the default, will
 	 * leave the scheme unchanged.
@@ -100,6 +102,17 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 	}
 
 	/**
+	 * Modifies the URI to add the given path prefix.
+	 * @param pathPrefix the path prefix to add
+	 * @return {@code this}
+	 */
+	public UriModifyingOperationPreprocessor pathPrefix(String pathPrefix) {
+		this.pathPrefix = pathPrefix;
+		this.contentModifier.setPathPrefix(pathPrefix);
+		return this;
+	}
+
+	/**
 	 * Removes the port from the URI.
 	 * @return {@code this}
 	 */
@@ -129,6 +142,10 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 			else {
 				uriBuilder.port(null);
 			}
+		}
+		if (this.pathPrefix != null) {
+			String rawPath = request.getUri().getRawPath();
+			uriBuilder.replacePath(this.pathPrefix + ((rawPath != null) ? rawPath : ""));
 		}
 		URI modifiedUri = uriBuilder.build(true).toUri();
 		HttpHeaders modifiedHeaders = modify(request.getHeaders());
@@ -177,6 +194,8 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 
 		private String port;
 
+		private String pathPrefix;
+
 		private void setScheme(String scheme) {
 			this.scheme = scheme;
 		}
@@ -187,6 +206,10 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 
 		private void setPort(String port) {
 			this.port = port;
+		}
+
+		private void setPathPrefix(String pathPrefix) {
+			this.pathPrefix = pathPrefix;
 		}
 
 		@Override
@@ -204,7 +227,8 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 
 		private String modify(String input) {
 			List<String> replacements = Arrays.asList(this.scheme, this.host,
-					StringUtils.hasText(this.port) ? ":" + this.port : this.port);
+					StringUtils.hasText(this.port) ? ":" + this.port : this.port,
+					this.pathPrefix);
 
 			int previous = 0;
 


### PR DESCRIPTION
Overview
---
1. Added pathPrefix field and setter method to UriModifyingOperationPreprocessor
2. Added corresponding support in UriModifyingContentModifier

Related Issues
---
#945 

Test
---
```java
@Test
public void requestContentUriPathIsPreservedAndAddPathPrefix() {
    this.preprocessor
		    .removePort()
		    .pathPrefix("/addPathPrefix");
    OperationRequest processed = this.preprocessor
	    .preprocess(createRequestWithContent("The uri 'http://localhost:12345/foo/bar' should be used"));
    assertThat(new String(processed.getContent())).isEqualTo("The uri 'http://localhost/addPathPrefix/foo/bar' should be used");
}

@Test
public void responseContentUriPathIsPreservedAndAddPathPrefix() {
    this.preprocessor
		    .removePort()
		    .pathPrefix("addPathPrefix");
    OperationResponse processed = this.preprocessor
	    .preprocess(createResponseWithContent("The uri 'http://localhost:12345/foo/bar' should be used"));
    assertThat(new String(processed.getContent())).isEqualTo("The uri 'http://localhost/addPathPrefix/foo/bar' should be used");
}
```
