### PR TITLE
Align bootJar example with changes to Asciidoctor's Gradle plugin

### DIFF
--- a/docs/src/docs/asciidoc/getting-started.adoc
+++ b/docs/src/docs/asciidoc/getting-started.adoc
@@ -181,7 +181,7 @@ If you are not using Spring Boot and its plugin management, declare the plugin w
 ----
 	bootJar {
 		dependsOn asciidoctor <1>
-		from ("${asciidoctor.outputDir}/html5") { <2>
+		from ("${asciidoctor.outputDir}") { <2>
 			into 'static/docs'
 		}
 	}


### PR DESCRIPTION
I could not get /html5 to work but removing it made it work.

It is also what is done in this example https://github.com/spring-projects/spring-restdocs-samples/blob/7ccbf89908ce1726c9c7dd30d291bb61f95436a3/rest-assured/build.gradle#L49