### PR TITLE
Support for official HAL and HAL-FORMS media type in link extraction

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/ContentTypeLinkExtractor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/ContentTypeLinkExtractor.java
@@ -30,6 +30,7 @@ import org.springframework.restdocs.operation.OperationResponse;
  * content type.
  *
  * @author Andy Wilkinson
+ * @author Oliver Drotbohm
  */
 class ContentTypeLinkExtractor implements LinkExtractor {
 
@@ -37,7 +38,11 @@ class ContentTypeLinkExtractor implements LinkExtractor {
 
 	ContentTypeLinkExtractor() {
 		this.linkExtractors.put(MediaType.APPLICATION_JSON, new AtomLinkExtractor());
-		this.linkExtractors.put(HalLinkExtractor.HAL_MEDIA_TYPE, new HalLinkExtractor());
+
+		LinkExtractor halLinkExtractor = new HalLinkExtractor();
+		this.linkExtractors.put(HalLinkExtractor.HAL_MEDIA_TYPE, halLinkExtractor);
+		this.linkExtractors.put(HalLinkExtractor.VND_HAL_MEDIA_TYPE, halLinkExtractor);
+		this.linkExtractors.put(HalLinkExtractor.HAL_FORMS_MEDIA_TYPE, halLinkExtractor);
 	}
 
 	ContentTypeLinkExtractor(Map<MediaType, LinkExtractor> linkExtractors) {

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HalLinkExtractor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/hypermedia/HalLinkExtractor.java
@@ -34,6 +34,8 @@ import org.springframework.http.MediaType;
 class HalLinkExtractor extends AbstractJsonLinkExtractor {
 
 	static final MediaType HAL_MEDIA_TYPE = new MediaType("application", "hal+json");
+	static final MediaType VND_HAL_MEDIA_TYPE = new MediaType("application", "vnd.hal+json");
+	static final MediaType HAL_FORMS_MEDIA_TYPE = new MediaType("application", "prs.hal-forms+json");
 
 	@Override
 	public Map<String, List<Link>> extractLinks(Map<String, Object> json) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/ContentTypeLinkExtractorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/hypermedia/ContentTypeLinkExtractorTests.java
@@ -18,6 +18,7 @@ package org.springframework.restdocs.hypermedia;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -28,6 +29,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.operation.OperationResponse;
 import org.springframework.restdocs.operation.OperationResponseFactory;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -40,6 +42,8 @@ import static org.mockito.Mockito.verify;
 public class ContentTypeLinkExtractorTests {
 
 	private final OperationResponseFactory responseFactory = new OperationResponseFactory();
+
+	private final String halBody = "{ \"_links\" : { \"someRel\" : { \"href\" : \"someHref\" }} }";
 
 	@Test
 	public void extractionFailsWithNullContentType() {
@@ -69,6 +73,24 @@ public class ContentTypeLinkExtractorTests {
 		OperationResponse response = this.responseFactory.create(HttpStatus.OK, httpHeaders, null);
 		new ContentTypeLinkExtractor(extractors).extractLinks(response);
 		verify(extractor).extractLinks(response);
+	}
+
+	@Test
+	public void extractsLinksFromVndHalMediaType() throws IOException {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setContentType(MediaType.parseMediaType("application/vnd.hal+json"));
+		OperationResponse response = this.responseFactory.create(HttpStatus.OK, httpHeaders, this.halBody.getBytes());
+		Map<String, List<Link>> links = new ContentTypeLinkExtractor().extractLinks(response);
+		assertThat(links).containsKey("someRel");
+	}
+
+	@Test
+	public void extractsLinksFromHalFormsMediaType() throws IOException {
+		HttpHeaders httpHeaders = new HttpHeaders();
+		httpHeaders.setContentType(MediaType.parseMediaType("application/prs.hal-forms+json"));
+		OperationResponse response = this.responseFactory.create(HttpStatus.OK, httpHeaders, this.halBody.getBytes());
+		Map<String, List<Link>> links = new ContentTypeLinkExtractor().extractLinks(response);
+		assertThat(links).containsKey("someRel");
 	}
 
 }


### PR DESCRIPTION
We now register the HalLinkExtractor for both the official HAL media type (application/vnd.hal+json) and the HAL-FORMS one (application/prs.hal-forms+json).
