### PR TITLE
Remove redundant append in MockMvcResponseConverter

### DIFF
--- a/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/MockMvcResponseConverter.java
+++ b/spring-restdocs-mockmvc/src/main/java/org/springframework/restdocs/mockmvc/MockMvcResponseConverter.java
@@ -107,7 +107,6 @@ class MockMvcResponseConverter implements ResponseConverter<MockHttpServletRespo
 
 	private void appendIfAvailable(StringBuilder header, String value) {
 		if (StringUtils.hasText(value)) {
-			header.append("");
 			header.append(value);
 		}
 	}


### PR DESCRIPTION
This commit removes a redundant append("") call in MockMvcResponseConverter.