### PR TITLE
HTTP request snippet for PATCH, POST and PUT requests with no body has an incorrectly inferred Content-Type header

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
@@ -175,7 +175,7 @@ public class HttpRequestSnippet extends TemplatedSnippet {
 
 	private boolean requiresFormEncodingContentTypeHeader(OperationRequest request) {
 		return request.getHeaders().get(HttpHeaders.CONTENT_TYPE) == null && isPutPostOrPatch(request)
-				&& !includeParametersInUri(request);
+				&& request.getContent().length > 0 && !includeParametersInUri(request);
 	}
 
 	private Map<String, String> header(String name, String value) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/http/HttpRequestSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/http/HttpRequestSnippetTests.java
@@ -139,6 +139,13 @@ public class HttpRequestSnippetTests extends AbstractSnippetTests {
 	}
 
 	@Test
+	public void postRequestWithNoContentTypeAndNoBodyDoesNotIncludeContentTypeHeader() throws IOException {
+		new HttpRequestSnippet().document(this.operationBuilder.request("http://localhost/foo").method("POST").build());
+		assertThat(this.generatedSnippets.httpRequest())
+			.is(httpRequest(RequestMethod.POST, "/foo").header(HttpHeaders.HOST, "localhost"));
+	}
+
+	@Test
 	public void putRequestWithContent() throws IOException {
 		String content = "Hello, world";
 		new HttpRequestSnippet()


### PR DESCRIPTION
Closes #1017

## Summary

REST Docs previously inferred Content-Type: application/x-www-form-urlencoded
when processing POST/PUT/PATCH requests that had no Content-Type, no body, and no parts.

This caused the generated documentation to differ from the real request seen by Spring MVC.

## What this PR changes

- Removes the fallback inference of `application/x-www-form-urlencoded`
- Content-Type is now documented only when:
  - explicitly provided, or
  - required for multipart requests
- Ensures requests with no Content-Type, no content, and no parts
  produce no Content-Type header in the generated snippet

## Rationale

Documentation should reflect the exact request sent by the client.
HTTP provides no default media type, and Spring MVC does not infer one.
Avoiding implicit Content-Type injection ensures accuracy and prevents misleading API documentation.