### PR TITLE
Remove duplicate null check for identifier in RestDocumentationGenerator

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/generate/RestDocumentationGenerator.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/generate/RestDocumentationGenerator.java
@@ -161,7 +161,6 @@ public final class RestDocumentationGenerator<REQ, RESP> {
 		Assert.notNull(identifier, "identifier must be non-null");
 		Assert.notNull(requestConverter, "requestConverter must be non-null");
 		Assert.notNull(responseConverter, "responseConverter must be non-null");
-		Assert.notNull(identifier, "identifier must be non-null");
 		Assert.notNull(requestPreprocessor, "requestPreprocessor must be non-null");
 		Assert.notNull(responsePreprocessor, "responsePreprocessor must be non-null");
 		Assert.notNull(snippets, "snippets must be non-null");


### PR DESCRIPTION
This PR removes a redundant null check for the identifier field in RestDocumentationGenerator.

Thank you.