### PR TITLE
fix: avoid inferring Content-Type without body

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/http/HttpRequestSnippet.java
@@ -178,7 +178,7 @@ public class HttpRequestSnippet extends TemplatedSnippet {
 
 	private boolean requiresFormEncodingContentTypeHeader(OperationRequest request) {
 		return request.getHeaders().get(HttpHeaders.CONTENT_TYPE) == null && isPutPostOrPatch(request)
-				&& !includeParametersInUri(request);
+				&& request.getContent().length > 0 && !includeParametersInUri(request);
 	}
 
 	private Map<String, String> header(String name, String value) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/http/HttpRequestSnippetTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/http/HttpRequestSnippetTests.java
@@ -102,6 +102,14 @@ class HttpRequestSnippetTests {
 	}
 
 	@RenderedSnippetTest
+	void postRequestWithoutContentDoesNotInferContentType(OperationBuilder operationBuilder,
+			AssertableSnippets snippets) throws IOException {
+		new HttpRequestSnippet().document(operationBuilder.request("http://localhost/foo").method("POST").build());
+		assertThat(snippets.httpRequest())
+			.isHttpRequest((request) -> request.post("/foo").header(HttpHeaders.HOST, "localhost"));
+	}
+
+	@RenderedSnippetTest
 	void postRequestWithContentAndQueryParameters(OperationBuilder operationBuilder, AssertableSnippets snippets)
 			throws IOException {
 		String content = "Hello, world";


### PR DESCRIPTION
## Summary
- Avoid adding application/x-www-form-urlencoded when POST/PUT/PATCH has no body
- Add a test to ensure no Content-Type header is inferred for empty POSTs

## Testing
- Not run (unit test added)

Fixes #1017