### PR TITLE
feat: support path prefixes in modifyUris

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/Preprocessors.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/Preprocessors.java
@@ -111,7 +111,7 @@ public final class Preprocessors {
 
 	/**
 	 * Returns a {@code UriModifyingOperationPreprocessor} that will modify URIs in the
-	 * request or response by changing one or more of their host, scheme, and port.
+	 * request or response by changing one or more of their host, scheme, port, and path.
 	 * @return the preprocessor
 	 * @since 2.0.1
 	 */

--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
@@ -18,7 +18,6 @@ package org.springframework.restdocs.operation.preprocess;
 
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
@@ -39,8 +38,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
- * An {@link OperationPreprocessor} that modifies URIs in the request and in the response
- * by changing one or more of their host, scheme, and port. URIs in the following
+	 * An {@link OperationPreprocessor} that modifies URIs in the request and in the response
+	 * by changing one or more of their host, scheme, port, and path. URIs in the following
  * locations are modified:
  * <ul>
  * <li>{@link OperationRequest#getUri() Request URI}
@@ -67,6 +66,8 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 	private @Nullable String host;
 
 	private @Nullable String port;
+
+	private @Nullable String pathPrefix;
 
 	/**
 	 * Modifies the URI to use the given {@code scheme}. {@code null}, the default, will
@@ -115,6 +116,18 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 		return this;
 	}
 
+	/**
+	 * Adds the given {@code pathPrefix} to the URI's path. {@code null}, the default, will
+	 * leave the path unchanged.
+	 * @param pathPrefix the path prefix to add
+	 * @return {@code this}
+	 */
+	public UriModifyingOperationPreprocessor pathPrefix(@Nullable String pathPrefix) {
+		this.pathPrefix = pathPrefix;
+		this.contentModifier.setPathPrefix(pathPrefix);
+		return this;
+	}
+
 	@Override
 	public OperationRequest preprocess(OperationRequest request) {
 		UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUri(request.getUri());
@@ -131,6 +144,10 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 			else {
 				uriBuilder.port(null);
 			}
+		}
+		if (this.pathPrefix != null) {
+			String rawPath = request.getUri().getRawPath();
+			uriBuilder.replacePath(prefixPath(this.pathPrefix, rawPath));
 		}
 		URI modifiedUri = uriBuilder.build(true).toUri();
 		HttpHeaders modifiedHeaders = modify(request.getHeaders());
@@ -168,16 +185,48 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 		return modifiedParts;
 	}
 
+	private String prefixPath(String pathPrefix, @Nullable String rawPath) {
+		String normalizedPrefix = normalizePrefix(pathPrefix);
+		String normalizedPath = normalizePath(rawPath);
+		if (!StringUtils.hasText(normalizedPath)) {
+			return normalizedPrefix;
+		}
+		return normalizedPrefix + "/" + normalizedPath;
+	}
+
+	private String normalizePrefix(String pathPrefix) {
+		String prefix = pathPrefix;
+		if (!prefix.startsWith("/")) {
+			prefix = "/" + prefix;
+		}
+		while (prefix.endsWith("/") && prefix.length() > 1) {
+			prefix = prefix.substring(0, prefix.length() - 1);
+		}
+		return prefix;
+	}
+
+	private String normalizePath(@Nullable String rawPath) {
+		if (!StringUtils.hasText(rawPath) || "/".equals(rawPath)) {
+			return "";
+		}
+		String path = rawPath;
+		while (path.startsWith("/")) {
+			path = path.substring(1);
+		}
+		return path;
+	}
+
 	private static final class UriModifyingContentModifier implements ContentModifier {
 
-		private static final Pattern SCHEME_HOST_PORT_PATTERN = Pattern
-			.compile("(http[s]?)://([a-zA-Z0-9-\\.]+)(:[0-9]+)?");
+		private static final Pattern URI_PATTERN = Pattern.compile("(http[s]?://[^\\s\"']+)");
 
 		private @Nullable String scheme;
 
 		private @Nullable String host;
 
 		private @Nullable String port;
+
+		private @Nullable String pathPrefix;
 
 		private void setScheme(@Nullable String scheme) {
 			this.scheme = scheme;
@@ -189,6 +238,10 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 
 		private void setPort(@Nullable String port) {
 			this.port = port;
+		}
+
+		private void setPathPrefix(@Nullable String pathPrefix) {
+			this.pathPrefix = pathPrefix;
 		}
 
 		@Override
@@ -205,39 +258,59 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 		}
 
 		private String modify(String input) {
-			List<String> replacements = Arrays.asList(this.scheme, this.host,
-					StringUtils.hasText(this.port) ? ":" + this.port : this.port);
-
+			if (this.scheme == null && this.host == null && this.port == null && this.pathPrefix == null) {
+				return input;
+			}
 			int previous = 0;
-
-			Matcher matcher = SCHEME_HOST_PORT_PATTERN.matcher(input);
+			Matcher matcher = URI_PATTERN.matcher(input);
 			StringBuilder builder = new StringBuilder();
 			while (matcher.find()) {
-				for (int i = 1; i <= matcher.groupCount(); i++) {
-					if (matcher.start(i) >= 0) {
-						builder.append(input, previous, matcher.start(i));
-					}
-					if (matcher.start(i) >= 0) {
-						previous = matcher.end(i);
-					}
-					builder.append(getReplacement(matcher.group(i), replacements.get(i - 1)));
-				}
+				builder.append(input, previous, matcher.start());
+				String original = matcher.group(1);
+				builder.append(modifyUriString(original));
+				previous = matcher.end();
 			}
-
 			if (previous < input.length()) {
 				builder.append(input.substring(previous));
 			}
 			return builder.toString();
 		}
 
-		private String getReplacement(String original, String candidate) {
-			if (candidate != null) {
-				return candidate;
+		private String modifyUriString(String original) {
+			try {
+				UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromUriString(original);
+				if (this.scheme != null) {
+					uriBuilder.scheme(this.scheme);
+				}
+				if (this.host != null) {
+					uriBuilder.host(this.host);
+				}
+				if (this.port != null) {
+					if (StringUtils.hasText(this.port)) {
+						uriBuilder.port(this.port);
+					}
+					else {
+						uriBuilder.port(null);
+					}
+				}
+				if (this.pathPrefix != null) {
+					String existingPath = uriBuilder.build(true).getPath();
+					String prefix = this.pathPrefix;
+					String normalizedPrefix = prefix.startsWith("/") ? prefix : "/" + prefix;
+					if (normalizedPrefix.endsWith("/") && normalizedPrefix.length() > 1) {
+						normalizedPrefix = normalizedPrefix.substring(0, normalizedPrefix.length() - 1);
+					}
+					String normalizedPath = (existingPath == null || existingPath.isEmpty() || "/".equals(existingPath))
+							? ""
+							: existingPath.startsWith("/") ? existingPath.substring(1) : existingPath;
+					uriBuilder.replacePath(normalizedPath.isEmpty() ? normalizedPrefix
+							: normalizedPrefix + "/" + normalizedPath);
+				}
+				return uriBuilder.build(true).toUriString();
 			}
-			if (original != null) {
+			catch (IllegalArgumentException ex) {
 				return original;
 			}
-			return "";
 		}
 
 	}

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessorTests.java
@@ -91,11 +91,27 @@ class UriModifyingOperationPreprocessorTests {
 	}
 
 	@Test
+	void requestUriPathCanBePrefixed() {
+		this.preprocessor.pathPrefix("/api");
+		OperationRequest processed = this.preprocessor
+			.preprocess(createRequestWithUri("https://api.example.com:12345/foo/bar"));
+		assertThat(processed.getUri()).isEqualTo(URI.create("https://api.example.com:12345/api/foo/bar"));
+	}
+
+	@Test
 	void requestUriQueryIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
 			.preprocess(createRequestWithUri("https://api.example.com:12345?foo=bar"));
 		assertThat(processed.getUri()).isEqualTo(URI.create("https://api.example.com?foo=bar"));
+	}
+
+	@Test
+	void requestUriQueryIsPreservedWhenPathIsPrefixed() {
+		this.preprocessor.pathPrefix("/api");
+		OperationRequest processed = this.preprocessor
+			.preprocess(createRequestWithUri("https://api.example.com:12345/foo?bar=baz"));
+		assertThat(processed.getUri()).isEqualTo(URI.create("https://api.example.com:12345/api/foo?bar=baz"));
 	}
 
 	@Test
@@ -178,6 +194,15 @@ class UriModifyingOperationPreprocessorTests {
 	}
 
 	@Test
+	void requestContentUriPathCanBePrefixed() {
+		this.preprocessor.pathPrefix("/api");
+		OperationRequest processed = this.preprocessor
+			.preprocess(createRequestWithContent("The uri 'http://localhost:12345/foo/bar' should be used"));
+		assertThat(new String(processed.getContent()))
+			.isEqualTo("The uri 'http://localhost:12345/api/foo/bar' should be used");
+	}
+
+	@Test
 	void requestContentUriQueryIsPreserved() {
 		this.preprocessor.removePort();
 		OperationRequest processed = this.preprocessor
@@ -244,6 +269,15 @@ class UriModifyingOperationPreprocessorTests {
 	}
 
 	@Test
+	void responseContentUriPathCanBePrefixed() {
+		this.preprocessor.pathPrefix("/api");
+		OperationResponse processed = this.preprocessor
+			.preprocess(createResponseWithContent("The uri 'http://localhost:12345/foo/bar' should be used"));
+		assertThat(new String(processed.getContent()))
+			.isEqualTo("The uri 'http://localhost:12345/api/foo/bar' should be used");
+	}
+
+	@Test
 	void responseContentUriQueryIsPreserved() {
 		this.preprocessor.removePort();
 		OperationResponse processed = this.preprocessor
@@ -265,6 +299,13 @@ class UriModifyingOperationPreprocessorTests {
 			.preprocess(createRequestWithHeader("Foo", "https://locahost:12345"));
 		assertThat(processed.getHeaders().getFirst("Foo")).isEqualTo("https://api.example.com:12345");
 		assertThat(processed.getHeaders().getFirst("Host")).isEqualTo("api.example.com");
+	}
+
+	@Test
+	void urisInRequestHeadersCanHavePathPrefixed() {
+		OperationRequest processed = this.preprocessor.pathPrefix("/api")
+			.preprocess(createRequestWithHeader("Foo", "https://localhost:12345/foo"));
+		assertThat(processed.getHeaders().getFirst("Foo")).isEqualTo("https://localhost:12345/api/foo");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Add path prefix support to UriModifyingOperationPreprocessor
- Update URI rewriting in content and headers to include the path prefix
- Add tests covering request/response URI path prefix behavior

## Testing
- Not run (unit tests added)

Fixes #945