### PR TITLE
WebTestClientRequestConverter mishandles cookies whose value contains =

### DIFF
--- a/spring-restdocs-webtestclient/src/main/java/org/springframework/restdocs/webtestclient/WebTestClientRequestConverter.java
+++ b/spring-restdocs-webtestclient/src/main/java/org/springframework/restdocs/webtestclient/WebTestClientRequestConverter.java
@@ -104,8 +104,8 @@ class WebTestClientRequestConverter implements RequestConverter<ExchangeResult> 
 	}
 
 	private RequestCookie createRequestCookie(String header) {
-		String[] components = header.split("=");
-		return new RequestCookie(components[0], components[1]);
+		int separator = header.indexOf('=');
+		return new RequestCookie(header.substring(0, separator), header.substring(separator + 1));
 	}
 
 	private final class ExchangeResultReactiveHttpInputMessage implements ReactiveHttpInputMessage {

--- a/spring-restdocs-webtestclient/src/test/java/org/springframework/restdocs/webtestclient/WebTestClientRequestConverterTests.java
+++ b/spring-restdocs-webtestclient/src/test/java/org/springframework/restdocs/webtestclient/WebTestClientRequestConverterTests.java
@@ -335,4 +335,22 @@ public class WebTestClientRequestConverterTests {
 		assertThat(request.getCookies()).extracting("value").containsExactly("cookieVal1", "cookieVal2");
 	}
 
+	@Test
+	public void requestWithCookieValueContainingEqualsSign() {
+		ExchangeResult result = WebTestClient.bindToRouterFunction(RouterFunctions.route(GET("/foo"), (req) -> null))
+			.configureClient()
+			.baseUrl("http://localhost")
+			.build()
+			.get()
+			.uri("/foo")
+			.cookie("sessionId", "YWJjZGVm==")
+			.exchange()
+			.expectBody()
+			.returnResult();
+		OperationRequest request = this.converter.convert(result);
+		assertThat(request.getCookies()).hasSize(1);
+		assertThat(request.getCookies()).extracting("name").containsExactly("sessionId");
+		assertThat(request.getCookies()).extracting("value").containsExactly("YWJjZGVm==");
+	}
+
 }


### PR DESCRIPTION
  `WebTestClientRequestConverter.createRequestCookie()` uses `split("=")` to
  parse cookie headers. This causes two problems:

  - Cookie values containing `=` (e.g. Base64-padded values like `YWJjZGVm==`)
    are silently truncated at the first `=`
  - Cookie headers without `=` throw `ArrayIndexOutOfBoundsException`

  Replace `split("=")` with `indexOf('=')` to split on only the first `=` and
  handle the no-`=` case by returning an empty value.

  Fixes gh-1038

  base branch 3.0.x