### PR TITLE
UriModifyingContentModifier.modifyContent decodes with the request charset but re-encodes with the platform default

### DIFF
--- a/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
+++ b/spring-restdocs-core/src/main/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessor.java
@@ -17,6 +17,7 @@
 package org.springframework.restdocs.operation.preprocess;
 
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -191,15 +192,9 @@ public class UriModifyingOperationPreprocessor implements OperationPreprocessor 
 
 		@Override
 		public byte[] modifyContent(byte[] content, MediaType contentType) {
-			String input;
-			if (contentType != null && contentType.getCharset() != null) {
-				input = new String(content, contentType.getCharset());
-			}
-			else {
-				input = new String(content);
-			}
-
-			return modify(input).getBytes();
+			Charset charset = (contentType != null && contentType.getCharset() != null) ? contentType.getCharset()
+					: Charset.defaultCharset();
+			return modify(new String(content, charset)).getBytes(charset);
 		}
 
 		private String modify(String input) {

--- a/spring-restdocs-core/src/test/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessorTests.java
+++ b/spring-restdocs-core/src/test/java/org/springframework/restdocs/operation/preprocess/UriModifyingOperationPreprocessorTests.java
@@ -17,6 +17,7 @@
 package org.springframework.restdocs.operation.preprocess;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.operation.OperationRequest;
 import org.springframework.restdocs.operation.OperationRequestFactory;
 import org.springframework.restdocs.operation.OperationRequestPart;
@@ -297,6 +299,32 @@ public class UriModifyingOperationPreprocessorTests {
 			.preprocess(createRequestWithUri("http://localhost:12345?foo=%7B%7D"));
 		assertThat(processed.getUri()).isEqualTo(URI.create("https://localhost:12345?foo=%7B%7D"));
 
+	}
+
+	@Test
+	public void requestContentWithNonAsciiCharactersIsPreservedWhenCharsetIsIso88591() {
+		this.preprocessor.scheme("https");
+		String original = "café http://localhost:12345 done";
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.parseMediaType("text/plain;charset=ISO-8859-1"));
+		OperationRequest request = this.requestFactory.create(URI.create("http://localhost"), HttpMethod.GET,
+				original.getBytes(StandardCharsets.ISO_8859_1), headers, Collections.<OperationRequestPart>emptyList());
+		OperationRequest processed = this.preprocessor.preprocess(request);
+		String result = new String(processed.getContent(), StandardCharsets.ISO_8859_1);
+		assertThat(result).isEqualTo("café https://localhost:12345 done");
+	}
+
+	@Test
+	public void responseContentWithNonAsciiCharactersIsPreservedWhenCharsetIsIso88591() {
+		this.preprocessor.scheme("https");
+		String original = "café http://localhost:12345 done";
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.parseMediaType("text/plain;charset=ISO-8859-1"));
+		OperationResponse response = this.responseFactory.create(HttpStatus.OK, headers,
+				original.getBytes(StandardCharsets.ISO_8859_1));
+		OperationResponse processed = this.preprocessor.preprocess(response);
+		String result = new String(processed.getContent(), StandardCharsets.ISO_8859_1);
+		assertThat(result).isEqualTo("café https://localhost:12345 done");
 	}
 
 	@Test


### PR DESCRIPTION
UriModifyingContentModifier.modifyContent() decodes the request/response
  body using the charset from the Content-Type header, but re-encodes with
  String.getBytes() (no charset argument), which falls back to the JVM
  default. When these differ, non-ASCII characters get corrupted.

  Use the same charset for both decoding and encoding, falling back to
  Charset.defaultCharset() when no charset is declared.

  Fixes gh-1039
  Supersedes #1041 (which became un-reopenable after force-push during merge processing).